### PR TITLE
[기능] 홈화면 버튼 통합 - 거래 시작하기와 내 물건 팔기 버튼 통합

### DIFF
--- a/src/components/features/home/HeroBanner.tsx
+++ b/src/components/features/home/HeroBanner.tsx
@@ -16,12 +16,9 @@ export function HeroBanner() {
             안전하고 편리한 거래 경험을 제공합니다.
           </p>
           <div className="flex justify-center gap-4 md:justify-start">
-            <Button size="lg" className="px-8 text-lg font-semibold">
-              거래 시작하기
-            </Button>
             <Link to="/seller/products/new">
-              <Button size="lg" variant="outline" className="px-8 text-lg font-semibold">
-                내 물건 팔기
+              <Button size="lg" className="px-8 text-lg font-semibold">
+                거래 시작하기
               </Button>
             </Link>
           </div>


### PR DESCRIPTION
## 변경 사항
- '거래 시작하기' 버튼 클릭 시 /seller/products/new로 이동
- '내 물건 팔기' 버튼 제거하여 UX 단순화

## 관련 Issue
Closes #1

## 테스트
- [x] 로컬에서 버튼 클릭 시 상품 등록 페이지로 이동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **사용자 인터페이스**
  * 홈 배너의 콜-투-액션 구조를 개편했습니다. "거래 시작하기" 버튼이 새로운 위치로 이동되고 중복된 버튼이 제거되어 사용자가 더욱 명확한 인터페이스를 이용할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->