### PR TITLE
[기능] 상품 그리드 무한 스크롤 페이징 구현

### DIFF
--- a/src/components/features/product/ProductList.tsx
+++ b/src/components/features/product/ProductList.tsx
@@ -1,12 +1,30 @@
 import type { Product } from '@/mocks/products';
 import { ProductCard } from './ProductCard';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { ProductSkeletonList } from './ProductSkeleton';
 
 interface ProductListProps {
   products: Product[];
   title?: string;
+  enableInfiniteScroll?: boolean;
 }
 
-export function ProductList({ products, title }: ProductListProps) {
+/**
+ * 상품 그리드 리스트 컴포넌트
+ * 무한 스크롤 페이징 및 스켈레톤 UI 지원
+ */
+export function ProductList({ 
+  products, 
+  title, 
+  enableInfiniteScroll = true 
+}: ProductListProps) {
+  const { displayItems, isLoading, hasMore, observerTarget } = useInfiniteScroll(products, {
+    pageSize: 12,
+  });
+
+  // 무한 스크롤 비활성화 시 전체 표시 (또는 기존 로직 유지 가능)
+  const itemsToRender = enableInfiniteScroll ? displayItems : products;
+
   return (
     <section className="container mx-auto py-12 px-4">
       {title && (
@@ -15,10 +33,26 @@ export function ProductList({ products, title }: ProductListProps) {
         </h2>
       )}
       
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-        {products.map((product) => (
+      {/* 
+        1줄당 4개 항목 표시 (md 이상에서 grid-cols-4 고정) 
+        데이터가 부족할 경우 grid의 기본 동작에 의해 왼쪽으로 정렬됨
+      */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+        {itemsToRender.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}
+        
+        {/* 로딩 중 스켈레톤 표시 */}
+        {isLoading && <ProductSkeletonList count={4} />}
+      </div>
+
+      {/* 무한 스크롤 관찰 대상 및 하단 메시지 */}
+      <div ref={observerTarget} className="mt-12 w-full py-8 text-center">
+        {!hasMore && products.length > 0 && (
+          <p className="text-neutral-500 font-medium animate-in fade-in slide-in-from-bottom-2 duration-500">
+            모든 상품을 다 확인했어요!
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/components/features/product/ProductSkeleton.tsx
+++ b/src/components/features/product/ProductSkeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * 상품 리스트 로딩 중 표시되는 스켈레톤 컴포넌트
+ * 기존 ProductCard와 레이아웃을 동일하게 유지하여 레이아웃 시프트를 방지함
+ */
+export function ProductSkeleton() {
+  return (
+    <div className="group flex flex-col gap-3 rounded-2xl bg-white p-3 shadow-sm ring-1 ring-neutral-200 animate-pulse">
+      {/* Image Skeleton */}
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-xl bg-neutral-200" />
+      
+      <div className="flex flex-col gap-2">
+        {/* Title Skeleton */}
+        <div className="h-4 w-3/4 rounded bg-neutral-200" />
+        
+        {/* Price Skeleton */}
+        <div className="flex items-center justify-between">
+          <div className="h-5 w-1/3 rounded bg-neutral-200 font-bold" />
+          <div className="h-3 w-1/4 rounded bg-neutral-200" />
+        </div>
+        
+        {/* Footer Skeleton */}
+        <div className="mt-1 flex items-center gap-1 border-t border-neutral-100 pt-2">
+          <div className="h-3 w-1/4 rounded bg-neutral-200" />
+          <div className="ml-auto flex gap-2">
+            <div className="h-3 w-6 rounded bg-neutral-200" />
+            <div className="h-3 w-6 rounded bg-neutral-200" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 여러 개의 고정된 개수의 스켈레톤을 표시하는 헬퍼 컴포넌트
+ */
+interface ProductSkeletonListProps {
+  count?: number;
+}
+
+export function ProductSkeletonList({ count = 4 }: ProductSkeletonListProps) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <ProductSkeleton key={`skeleton-${i}`} />
+      ))}
+    </>
+  );
+}

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+interface UseInfiniteScrollOptions {
+  pageSize: number;
+  rootMargin?: string;
+}
+
+/**
+ * 무한 스크롤 로직을 담당하는 커스텀 훅
+ * @param allItems 전체 아이템 리스트 (목업 단계이므로 클라이언트 사이드 페이징 수행)
+ * @param options pageSize 및 IntersectionObserver 옵션
+ */
+export function useInfiniteScroll<T>(
+  allItems: T[],
+  { pageSize, rootMargin = '200px' }: UseInfiniteScrollOptions
+) {
+  const [displayItems, setDisplayItems] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  // 초기화 및 아이템 추가 로드
+  const loadMore = useCallback(() => {
+    if (isLoading || !hasMore) return;
+
+    setIsLoading(true);
+    
+    // 목업을 위한 지연 시간 (0.5초)
+    setTimeout(() => {
+      const currentCount = displayItems.length;
+      const nextItems = allItems.slice(0, currentCount + pageSize);
+      
+      setDisplayItems(nextItems);
+      setHasMore(nextItems.length < allItems.length);
+      setIsLoading(false);
+    }, 500);
+  }, [allItems, displayItems.length, hasMore, isLoading, pageSize]);
+
+  // 전체 아이템이나 필터가 변경될 때 초기화
+  useEffect(() => {
+    const initialItems = allItems.slice(0, pageSize);
+    setDisplayItems(initialItems);
+    setHasMore(initialItems.length < allItems.length);
+    setIsLoading(false);
+  }, [allItems, pageSize]);
+
+  // Intersection Observer 설정
+  useEffect(() => {
+    const target = observerTarget.current;
+    if (!target || !hasMore) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin }
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore, rootMargin]);
+
+  return {
+    displayItems,
+    isLoading,
+    hasMore,
+    observerTarget,
+  };
+}


### PR DESCRIPTION
## 개요
상품 리스트를 표시하는 모든 페이지에 무한 스크롤 방식의 페이징을 구현했습니다.

## 변경 사항
- [x] **무한 스크롤 커스텀 훅(useInfiniteScroll)** 개발 (pageSize: 12, buffer: 200px)
- [x] **스켈레톤 UI(ProductSkeleton)** 추가하여 로딩 중 레이아웃 유지
- [x] **ProductList 고도화**: 데스크톱 4열 그리드 고정 및 하단 '모든 상품 확인' 메시지 추가
- [x] 홈, 검색, 카테고리 페이지 일괄 적용 확인

## 관련 이슈
Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 무한 스크롤 기능 추가 - 상품 목록을 아래로 스크롤하면 자동으로 더 많은 상품이 로드됩니다
* 스켈레톤 로딩 애니메이션 추가 - 상품 데이터가 로드되는 동안 시각적 피드백을 제공합니다
* 상품 그리드 레이아웃 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->