### PR TITLE
[수정] 프로필 정보 마이페이지 표시, ProfilePage 수정 전용

### DIFF
--- a/src/components/features/mypage/ProfileCard.tsx
+++ b/src/components/features/mypage/ProfileCard.tsx
@@ -1,61 +1,171 @@
 /**
- * 프로필 카드 컴포넌트
+ * 프로필 카드 컴포넌트 (확장형)
  */
 
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { User } from '../../../mocks/users';
-import { Settings } from 'lucide-react';
+import { Settings, ChevronDown, ChevronUp, Mail, Phone, CreditCard, Calendar, Coins } from 'lucide-react';
 
 interface ProfileCardProps {
   user: User;
 }
 
 const ProfileCard = ({ user }: ProfileCardProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  };
+
   return (
-    <div className="bg-white rounded-2xl p-6 border border-neutral-200">
-      <div className="flex items-start gap-4">
-        {/* 아바타 */}
-        <div className="w-20 h-20 rounded-full overflow-hidden bg-neutral-200 flex-shrink-0">
-          {user.avatar ? (
-            <img
-              src={user.avatar}
-              alt={user.nickname}
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-2xl font-bold text-neutral-400">
-              {user.nickname.charAt(0)}
+    <div className="bg-white rounded-2xl border border-neutral-200 overflow-hidden">
+      {/* 기본 프로필 영역 */}
+      <div className="p-6">
+        <div className="flex items-start gap-4">
+          {/* 아바타 */}
+          <div className="w-20 h-20 rounded-full overflow-hidden bg-neutral-200 flex-shrink-0">
+            {user.avatar ? (
+              <img
+                src={user.avatar}
+                alt={user.nickname}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-2xl font-bold text-neutral-400">
+                {user.nickname.charAt(0)}
+              </div>
+            )}
+          </div>
+
+          {/* 프로필 정보 */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <h2 className="text-xl font-bold text-neutral-900">{user.nickname}</h2>
+              <Link
+                to="/mypage/profile"
+                className="p-1.5 rounded-full hover:bg-neutral-100 transition-colors"
+                title="수정"
+              >
+                <Settings className="w-4 h-4 text-neutral-400" />
+              </Link>
             </div>
-          )}
+            <p className="text-sm text-neutral-500 mb-2">{user.email}</p>
+            {user.intro && (
+              <p className="text-sm text-neutral-700 line-clamp-2">{user.intro}</p>
+            )}
+          </div>
         </div>
 
-        {/* 프로필 정보 */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <h2 className="text-xl font-bold text-neutral-900">{user.nickname}</h2>
-            <Link
-              to="/mypage/profile"
-              className="p-1.5 rounded-full hover:bg-neutral-100 transition-colors"
-              title="설정"
-            >
-              <Settings className="w-4 h-4 text-neutral-400" />
-            </Link>
-          </div>
-          <p className="text-sm text-neutral-500 mb-2">{user.email}</p>
-          {user.intro && (
-            <p className="text-sm text-neutral-700 line-clamp-2">{user.intro}</p>
+        {/* 상세 정보 토글 버튼 */}
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="mt-4 w-full flex items-center justify-center gap-1 py-2 text-sm font-medium text-neutral-500 hover:text-neutral-700 transition-colors"
+        >
+          {isExpanded ? (
+            <>상세 정보 접기 <ChevronUp className="w-4 h-4" /></>
+          ) : (
+            <>상세 정보 보기 <ChevronDown className="w-4 h-4" /></>
           )}
-        </div>
+        </button>
       </div>
 
+      {/* 확장 영역 */}
+      {isExpanded && (
+        <div className="border-t border-neutral-100 bg-neutral-50 px-6 py-4 space-y-4">
+          {/* 연락처 정보 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
+                <Mail className="w-4 h-4 text-blue-500" />
+              </div>
+              <div>
+                <p className="text-xs text-neutral-400">이메일</p>
+                <p className="text-sm font-medium text-neutral-900 truncate">{user.email}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
+                <Phone className="w-4 h-4 text-green-500" />
+              </div>
+              <div>
+                <p className="text-xs text-neutral-400">휴대폰</p>
+                <p className="text-sm font-medium text-neutral-900">{user.phone || '미등록'}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 계정 정보 */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center">
+                <Calendar className="w-4 h-4 text-purple-500" />
+              </div>
+              <div>
+                <p className="text-xs text-neutral-400">가입일</p>
+                <p className="text-sm font-medium text-neutral-900">{formatDate(user.createdAt)}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-yellow-100 flex items-center justify-center">
+                <Coins className="w-4 h-4 text-yellow-500" />
+              </div>
+              <div>
+                <p className="text-xs text-neutral-400">포인트</p>
+                <p className="text-sm font-medium text-neutral-900">{user.point.toLocaleString()}P</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 정산 계좌 */}
+          <div className="pt-3 border-t border-neutral-200">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-neutral-500">정산 계좌</span>
+              <Link
+                to="/mypage/settlement"
+                className="text-xs font-medium text-primary-500 hover:text-primary-600"
+              >
+                {user.settlementAccount ? '변경' : '등록'}
+              </Link>
+            </div>
+            {user.settlementAccount ? (
+              <div className="flex items-center gap-2">
+                <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
+                  <CreditCard className="w-4 h-4 text-emerald-500" />
+                </div>
+                <div>
+                  <p className="text-xs text-neutral-400">{user.settlementAccount.bank}</p>
+                  <p className="text-sm font-medium text-neutral-900">
+                    {user.settlementAccount.accountNumber} ({user.settlementAccount.holder})
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 p-2 bg-orange-50 rounded-lg">
+                <div className="w-8 h-8 rounded-full bg-orange-100 flex items-center justify-center">
+                  <CreditCard className="w-4 h-4 text-orange-500" />
+                </div>
+                <p className="text-sm font-medium text-orange-600">등록이 필요합니다</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* 프로필 수정 버튼 */}
-      <Link
-        to="/mypage/profile"
-        className="mt-4 block w-full py-2.5 text-center text-sm font-medium text-neutral-700
-                   bg-neutral-100 rounded-xl hover:bg-neutral-200 transition-colors"
-      >
-        프로필 수정
-      </Link>
+      <div className="border-t border-neutral-100 px-6 py-3">
+        <Link
+          to="/mypage/profile"
+          className="block w-full py-2.5 text-center text-sm font-medium text-neutral-700
+                     bg-neutral-100 rounded-xl hover:bg-neutral-200 transition-colors"
+        >
+          프로필 수정
+        </Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,10 +1,10 @@
 /**
- * 프로필 페이지 (보기/수정 통합)
+ * 프로필 수정 페이지
  */
 
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, Camera, Edit2, CreditCard, Phone, Mail, Calendar, Coins } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Camera } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { useToast } from '@/components/common/Toast';
 import { MOCK_USER } from '@/mocks/users';
@@ -12,9 +12,6 @@ import { MOCK_USER } from '@/mocks/users';
 const ProfilePage = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
-  const [searchParams, setSearchParams] = useSearchParams();
-  
-  const isEditMode = searchParams.get('mode') === 'edit';
   
   const [nickname, setNickname] = useState(MOCK_USER.nickname);
   const [intro, setIntro] = useState(MOCK_USER.intro || '');
@@ -22,51 +19,25 @@ const ProfilePage = () => {
 
   const handleSave = () => {
     showToast('프로필이 수정되었습니다.', 'success');
-    setSearchParams({});
+    navigate('/mypage');
   };
 
   const handleCancel = () => {
-    setNickname(MOCK_USER.nickname);
-    setIntro(MOCK_USER.intro || '');
-    setSearchParams({});
-  };
-
-  const handleEdit = () => {
-    setSearchParams({ mode: 'edit' });
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
+    navigate('/mypage');
   };
 
   return (
     <div className="min-h-screen bg-neutral-50 py-6 pb-20">
       <div className="max-w-lg mx-auto px-4">
         {/* 헤더 */}
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => navigate('/mypage')}
-              className="p-2 -ml-2 rounded-full hover:bg-neutral-100 transition-colors"
-            >
-              <ArrowLeft className="w-5 h-5 text-neutral-700" />
-            </button>
-            <h1 className="text-xl font-bold text-neutral-900">
-              {isEditMode ? '프로필 수정' : '내 프로필'}
-            </h1>
-          </div>
-          {!isEditMode && (
-            <button
-              onClick={handleEdit}
-              className="p-2 rounded-full hover:bg-neutral-100 transition-colors"
-            >
-              <Edit2 className="w-5 h-5 text-neutral-600" />
-            </button>
-          )}
+        <div className="flex items-center gap-3 mb-6">
+          <button
+            onClick={() => navigate(-1)}
+            className="p-2 -ml-2 rounded-full hover:bg-neutral-100 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5 text-neutral-700" />
+          </button>
+          <h1 className="text-xl font-bold text-neutral-900">프로필 수정</h1>
         </div>
 
         {/* 프로필 이미지 */}
@@ -81,153 +52,75 @@ const ProfilePage = () => {
                 </div>
               )}
             </div>
-            {isEditMode && (
-              <button 
-                className="absolute bottom-0 right-0 w-8 h-8 bg-primary-500 rounded-full flex items-center justify-center text-white shadow-md hover:bg-primary-600 transition-colors"
-                onClick={() => showToast('이미지 업로드는 목업입니다.', 'info')}
-              >
-                <Camera className="w-4 h-4" />
-              </button>
-            )}
+            <button 
+              className="absolute bottom-0 right-0 w-8 h-8 bg-primary-500 rounded-full flex items-center justify-center text-white shadow-md hover:bg-primary-600 transition-colors"
+              onClick={() => showToast('이미지 업로드는 목업입니다.', 'info')}
+            >
+              <Camera className="w-4 h-4" />
+            </button>
           </div>
         </div>
 
-        {isEditMode ? (
-          /* 수정 모드 */
-          <div className="space-y-6">
-            <div>
-              <label className="block text-sm font-medium text-neutral-700 mb-2">닉네임</label>
-              <input
-                type="text"
-                value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
-                className="w-full px-4 py-3 border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-neutral-700 mb-2">소개</label>
-              <textarea
-                value={intro}
-                onChange={(e) => setIntro(e.target.value)}
-                rows={4}
-                className="w-full px-4 py-3 border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
-              />
-            </div>
-            <div className="flex gap-3 mt-8">
-              <Button variant="outline" className="flex-1" onClick={handleCancel}>취소</Button>
-              <Button variant="primary" className="flex-1" onClick={handleSave}>저장</Button>
-            </div>
+        {/* 폼 */}
+        <div className="space-y-6">
+          {/* 닉네임 */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-2">닉네임</label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              className="w-full px-4 py-3 border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              placeholder="닉네임을 입력하세요"
+            />
           </div>
-        ) : (
-          /* 보기 모드 */
-          <div className="space-y-4">
-            {/* 기본 정보 카드 */}
-            <div className="bg-white rounded-2xl p-5 border border-neutral-200">
-              <h2 className="text-sm font-bold text-neutral-500 mb-4">기본 정보</h2>
-              <div className="space-y-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-neutral-100 flex items-center justify-center">
-                    <span className="text-lg font-bold text-neutral-600">{nickname.charAt(0)}</span>
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">닉네임</p>
-                    <p className="font-medium text-neutral-900">{nickname}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-blue-50 flex items-center justify-center">
-                    <Mail className="w-4 h-4 text-blue-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">이메일</p>
-                    <p className="font-medium text-neutral-900">{MOCK_USER.email}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-green-50 flex items-center justify-center">
-                    <Phone className="w-4 h-4 text-green-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">휴대폰</p>
-                    <p className="font-medium text-neutral-900">{MOCK_USER.phone || '미등록'}</p>
-                  </div>
-                </div>
-                {intro && (
-                  <div className="pt-3 border-t border-neutral-100">
-                    <p className="text-xs text-neutral-400 mb-1">소개</p>
-                    <p className="text-sm text-neutral-700">{intro}</p>
-                  </div>
-                )}
-              </div>
-            </div>
 
-            {/* 계정 정보 카드 */}
-            <div className="bg-white rounded-2xl p-5 border border-neutral-200">
-              <h2 className="text-sm font-bold text-neutral-500 mb-4">계정 정보</h2>
-              <div className="space-y-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-purple-50 flex items-center justify-center">
-                    <Calendar className="w-4 h-4 text-purple-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">가입일</p>
-                    <p className="font-medium text-neutral-900">{formatDate(MOCK_USER.createdAt)}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-yellow-50 flex items-center justify-center">
-                    <Coins className="w-4 h-4 text-yellow-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">보유 포인트</p>
-                    <p className="font-medium text-neutral-900">{MOCK_USER.point.toLocaleString()}P</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* 정산 계좌 카드 */}
-            <div className="bg-white rounded-2xl p-5 border border-neutral-200">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-bold text-neutral-500">정산 계좌</h2>
-                <button
-                  onClick={() => navigate('/mypage/settlement')}
-                  className="text-xs font-medium text-primary-500 hover:text-primary-600"
-                >
-                  {MOCK_USER.settlementAccount ? '변경' : '등록'}
-                </button>
-              </div>
-              {MOCK_USER.settlementAccount ? (
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 rounded-full bg-emerald-50 flex items-center justify-center">
-                    <CreditCard className="w-4 h-4 text-emerald-500" />
-                  </div>
-                  <div>
-                    <p className="text-xs text-neutral-400">{MOCK_USER.settlementAccount.bank}</p>
-                    <p className="font-medium text-neutral-900">
-                      {MOCK_USER.settlementAccount.accountNumber} ({MOCK_USER.settlementAccount.holder})
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-3 p-3 bg-orange-50 rounded-xl">
-                  <div className="w-9 h-9 rounded-full bg-orange-100 flex items-center justify-center">
-                    <CreditCard className="w-4 h-4 text-orange-500" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-orange-700">등록이 필요합니다</p>
-                    <p className="text-xs text-orange-500">판매 대금을 받으려면 계좌를 등록하세요</p>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* 수정 버튼 */}
-            <Button variant="outline" className="w-full mt-4" onClick={handleEdit}>
-              프로필 수정
-            </Button>
+          {/* 소개 */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-2">소개</label>
+            <textarea
+              value={intro}
+              onChange={(e) => setIntro(e.target.value)}
+              rows={4}
+              className="w-full px-4 py-3 border border-neutral-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+              placeholder="자기소개를 입력하세요"
+            />
           </div>
-        )}
+
+          {/* 이메일 (읽기 전용) */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-2">이메일</label>
+            <input
+              type="email"
+              value={MOCK_USER.email}
+              disabled
+              className="w-full px-4 py-3 border border-neutral-200 rounded-xl bg-neutral-100 text-neutral-500 cursor-not-allowed"
+            />
+            <p className="mt-1 text-xs text-neutral-400">이메일은 변경할 수 없습니다.</p>
+          </div>
+
+          {/* 휴대폰 (읽기 전용) */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-2">휴대폰</label>
+            <input
+              type="tel"
+              value={MOCK_USER.phone || ''}
+              disabled
+              className="w-full px-4 py-3 border border-neutral-200 rounded-xl bg-neutral-100 text-neutral-500 cursor-not-allowed"
+            />
+            <p className="mt-1 text-xs text-neutral-400">휴대폰 번호 변경은 고객센터에 문의하세요.</p>
+          </div>
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex gap-3 mt-8">
+          <Button variant="outline" className="flex-1" onClick={handleCancel}>
+            취소
+          </Button>
+          <Button variant="primary" className="flex-1" onClick={handleSave}>
+            저장
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 개요
프로필 정보를 마이페이지에서 바로 확인할 수 있도록 하고, /mypage/profile은 수정 전용으로 변경합니다.

## 변경 사항
- ProfileCard 확장형으로 재작성 (토글 UI)
- 이메일, 휴대폰, 정산 계좌 정보 표시
- ProfilePage 보기 모드 제거, 수정 전용

Closes #38