### PR TITLE
[UI] ProfileCard 레이아웃 개선 및 정산 카드 분리

### DIFF
--- a/src/components/features/mypage/ProfileCard.tsx
+++ b/src/components/features/mypage/ProfileCard.tsx
@@ -1,19 +1,16 @@
 /**
- * 프로필 카드 컴포넌트 (확장형)
+ * 프로필 카드 컴포넌트 (기본 프로필 정보)
  */
 
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { User } from '../../../mocks/users';
-import { Settings, ChevronDown, ChevronUp, Mail, Phone, CreditCard, Calendar, Coins } from 'lucide-react';
+import { Mail, Phone, Calendar } from 'lucide-react';
 
 interface ProfileCardProps {
   user: User;
 }
 
 const ProfileCard = ({ user }: ProfileCardProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString('ko-KR', {
       year: 'numeric',
@@ -23,148 +20,72 @@ const ProfileCard = ({ user }: ProfileCardProps) => {
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-neutral-200 overflow-hidden">
-      {/* 기본 프로필 영역 */}
-      <div className="p-6">
-        <div className="flex items-start gap-4">
-          {/* 아바타 */}
-          <div className="w-20 h-20 rounded-full overflow-hidden bg-neutral-200 flex-shrink-0">
-            {user.avatar ? (
-              <img
-                src={user.avatar}
-                alt={user.nickname}
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-2xl font-bold text-neutral-400">
-                {user.nickname.charAt(0)}
-              </div>
-            )}
-          </div>
-
-          {/* 프로필 정보 */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h2 className="text-xl font-bold text-neutral-900">{user.nickname}</h2>
-              <Link
-                to="/mypage/profile"
-                className="p-1.5 rounded-full hover:bg-neutral-100 transition-colors"
-                title="수정"
-              >
-                <Settings className="w-4 h-4 text-neutral-400" />
-              </Link>
-            </div>
-            <p className="text-sm text-neutral-500 mb-2">{user.email}</p>
-            {user.intro && (
-              <p className="text-sm text-neutral-700 line-clamp-2">{user.intro}</p>
-            )}
-          </div>
-        </div>
-
-        {/* 상세 정보 토글 버튼 */}
-        <button
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="mt-4 w-full flex items-center justify-center gap-1 py-2 text-sm font-medium text-neutral-500 hover:text-neutral-700 transition-colors"
-        >
-          {isExpanded ? (
-            <>상세 정보 접기 <ChevronUp className="w-4 h-4" /></>
+    <div className="bg-white rounded-2xl border border-neutral-200 p-6">
+      {/* 프로필 헤더 */}
+      <div className="flex items-start gap-4 mb-6">
+        {/* 아바타 */}
+        <div className="w-16 h-16 rounded-full overflow-hidden bg-neutral-200 flex-shrink-0">
+          {user.avatar ? (
+            <img
+              src={user.avatar}
+              alt={user.nickname}
+              className="w-full h-full object-cover"
+            />
           ) : (
-            <>상세 정보 보기 <ChevronDown className="w-4 h-4" /></>
+            <div className="w-full h-full flex items-center justify-center text-xl font-bold text-neutral-400">
+              {user.nickname.charAt(0)}
+            </div>
           )}
-        </button>
-      </div>
-
-      {/* 확장 영역 */}
-      {isExpanded && (
-        <div className="border-t border-neutral-100 bg-neutral-50 px-6 py-4 space-y-4">
-          {/* 연락처 정보 */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
-                <Mail className="w-4 h-4 text-blue-500" />
-              </div>
-              <div>
-                <p className="text-xs text-neutral-400">이메일</p>
-                <p className="text-sm font-medium text-neutral-900 truncate">{user.email}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
-                <Phone className="w-4 h-4 text-green-500" />
-              </div>
-              <div>
-                <p className="text-xs text-neutral-400">휴대폰</p>
-                <p className="text-sm font-medium text-neutral-900">{user.phone || '미등록'}</p>
-              </div>
-            </div>
-          </div>
-
-          {/* 계정 정보 */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center">
-                <Calendar className="w-4 h-4 text-purple-500" />
-              </div>
-              <div>
-                <p className="text-xs text-neutral-400">가입일</p>
-                <p className="text-sm font-medium text-neutral-900">{formatDate(user.createdAt)}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-yellow-100 flex items-center justify-center">
-                <Coins className="w-4 h-4 text-yellow-500" />
-              </div>
-              <div>
-                <p className="text-xs text-neutral-400">포인트</p>
-                <p className="text-sm font-medium text-neutral-900">{user.point.toLocaleString()}P</p>
-              </div>
-            </div>
-          </div>
-
-          {/* 정산 계좌 */}
-          <div className="pt-3 border-t border-neutral-200">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs font-medium text-neutral-500">정산 계좌</span>
-              <Link
-                to="/mypage/settlement"
-                className="text-xs font-medium text-primary-500 hover:text-primary-600"
-              >
-                {user.settlementAccount ? '변경' : '등록'}
-              </Link>
-            </div>
-            {user.settlementAccount ? (
-              <div className="flex items-center gap-2">
-                <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-                  <CreditCard className="w-4 h-4 text-emerald-500" />
-                </div>
-                <div>
-                  <p className="text-xs text-neutral-400">{user.settlementAccount.bank}</p>
-                  <p className="text-sm font-medium text-neutral-900">
-                    {user.settlementAccount.accountNumber} ({user.settlementAccount.holder})
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2 p-2 bg-orange-50 rounded-lg">
-                <div className="w-8 h-8 rounded-full bg-orange-100 flex items-center justify-center">
-                  <CreditCard className="w-4 h-4 text-orange-500" />
-                </div>
-                <p className="text-sm font-medium text-orange-600">등록이 필요합니다</p>
-              </div>
-            )}
-          </div>
         </div>
-      )}
 
-      {/* 프로필 수정 버튼 */}
-      <div className="border-t border-neutral-100 px-6 py-3">
+        {/* 닉네임 & 소개 */}
+        <div className="flex-1 min-w-0">
+          <h2 className="text-xl font-bold text-neutral-900 mb-1">{user.nickname}</h2>
+          {user.intro && (
+            <p className="text-sm text-neutral-600 line-clamp-2">{user.intro}</p>
+          )}
+        </div>
+
+        {/* 수정 버튼 */}
         <Link
           to="/mypage/profile"
-          className="block w-full py-2.5 text-center text-sm font-medium text-neutral-700
-                     bg-neutral-100 rounded-xl hover:bg-neutral-200 transition-colors"
+          className="px-3 py-1.5 text-xs font-medium text-primary-500 border border-primary-200 rounded-lg hover:bg-primary-50 transition-colors flex-shrink-0"
         >
-          프로필 수정
+          수정
         </Link>
+      </div>
+
+      {/* 연락처 & 가입일 */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="flex items-center gap-3 p-3 bg-neutral-50 rounded-xl">
+          <div className="w-9 h-9 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
+            <Mail className="w-4 h-4 text-blue-500" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-neutral-400">이메일</p>
+            <p className="text-sm font-medium text-neutral-900 truncate">{user.email}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 p-3 bg-neutral-50 rounded-xl">
+          <div className="w-9 h-9 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0">
+            <Phone className="w-4 h-4 text-green-500" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-neutral-400">휴대폰</p>
+            <p className="text-sm font-medium text-neutral-900">{user.phone || '미등록'}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 p-3 bg-neutral-50 rounded-xl">
+          <div className="w-9 h-9 rounded-full bg-purple-100 flex items-center justify-center flex-shrink-0">
+            <Calendar className="w-4 h-4 text-purple-500" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-neutral-400">가입일</p>
+            <p className="text-sm font-medium text-neutral-900">{formatDate(user.createdAt)}</p>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/features/mypage/SettlementCard.tsx
+++ b/src/components/features/mypage/SettlementCard.tsx
@@ -1,0 +1,58 @@
+/**
+ * 정산 계좌 카드 컴포넌트
+ */
+
+import { Link } from 'react-router-dom';
+import type { User } from '../../../mocks/users';
+import { CreditCard, ChevronRight } from 'lucide-react';
+
+interface SettlementCardProps {
+  user: User;
+}
+
+const SettlementCard = ({ user }: SettlementCardProps) => {
+  const { settlementAccount } = user;
+
+  return (
+    <div className="bg-white rounded-2xl border border-neutral-200 p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-bold text-neutral-700">정산 계좌</h3>
+        <Link
+          to="/mypage/settlement"
+          className="flex items-center gap-1 text-xs font-medium text-primary-500 hover:text-primary-600"
+        >
+          {settlementAccount ? '변경' : '등록'}
+          <ChevronRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {settlementAccount ? (
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+            <CreditCard className="w-5 h-5 text-emerald-500" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-neutral-900">
+              {settlementAccount.bank}
+            </p>
+            <p className="text-xs text-neutral-500">
+              {settlementAccount.accountNumber} ({settlementAccount.holder})
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 p-3 bg-orange-50 rounded-xl">
+          <div className="w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center flex-shrink-0">
+            <CreditCard className="w-5 h-5 text-orange-500" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-orange-700">등록이 필요합니다</p>
+            <p className="text-xs text-orange-500">판매 대금을 받으려면 계좌를 등록하세요</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SettlementCard;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,6 +9,7 @@ import { MOCK_USER, MOCK_ORDER_HISTORY, MOCK_SALES_PRODUCTS } from '../mocks/use
 
 import ProfileCard from '../components/features/mypage/ProfileCard';
 import ProfileStats from '../components/features/mypage/ProfileStats';
+import SettlementCard from '../components/features/mypage/SettlementCard';
 import SalesTabs from '../components/features/mypage/SalesTabs';
 import MyPageNav from '../components/features/mypage/MyPageNav';
 
@@ -37,6 +38,9 @@ const MyPage = () => {
           purchaseCount={purchaseCount}
           point={MOCK_USER.point}
         />
+
+        {/* 정산 계좌 */}
+        <SettlementCard user={MOCK_USER} />
 
         {/* 빠른 메뉴 */}
         <MyPageNav likeCount={likeCount} orderCount={purchaseCount} />


### PR DESCRIPTION
## 개요
마이페이지 ProfileCard UI 개선

## 변경 사항
- 중복 정보 제거
- 접기/펼치기 제거, 항상 펼쳐서 표시
- 설정 버튼 제거
- 연관 기능끼리 묶어서 레이아웃 수정
- SettlementCard 별도 컴포넌트 분리

Closes #40