### PR TITLE
[수정] 상품 상태 이름 통일

### DIFF
--- a/src/components/features/seller/ProductForm.tsx
+++ b/src/components/features/seller/ProductForm.tsx
@@ -31,12 +31,12 @@ interface ProductFormProps {
   submitLabel?: string;
 }
 
-// 상품 상태 옵션
+// 상품 상태 옵션 (ENUM 기준 통일)
 const CONDITION_OPTIONS: { value: ConditionStatus; label: string; description: string }[] = [
   { value: 'SEALED', label: '미개봉', description: '새 상품 (포장 미개봉)' },
-  { value: 'NO_WEAR', label: '거의 새것', description: '사용감 없음' },
+  { value: 'NO_WEAR', label: '사용감 없음', description: '거의 새것 수준' },
   { value: 'MINOR_WEAR', label: '사용감 적음', description: '눈에 띄지 않는 사용감' },
-  { value: 'VISIBLE_WEAR', label: '사용감 있음', description: '눈에 띄는 사용감' },
+  { value: 'VISIBLE_WEAR', label: '사용감 많음', description: '눈에 띄는 사용감' },
   { value: 'DAMAGED', label: '하자 있음', description: '기능/외관 하자' },
 ];
 


### PR DESCRIPTION
ProductForm의 상품 상태 라벨을 ProductDetailPage와 통일

- NO_WEAR: 거의 새것 -> 사용감 없음
- VISIBLE_WEAR: 사용감 있음 -> 사용감 많음

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 상품 조건 옵션의 레이블과 설명 텍스트를 일관되게 개선하였습니다. 사용감 없음, 사용감 많음 등의 표현이 명확하게 정렬되어 제품 상태 선택 시 더욱 명확한 정보를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->