### PR TITLE
[수정] 관리자 레이아웃 고도화 및 테이블 깨짐 수정

### DIFF
--- a/src/components/features/admin/AdminCouponList.tsx
+++ b/src/components/features/admin/AdminCouponList.tsx
@@ -313,7 +313,7 @@ export function AdminCouponList() {
       <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
         {coupons.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full">
+            <table className="w-full min-w-[900px]">
               <thead className="bg-neutral-50 border-b border-neutral-200">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">상태</th>

--- a/src/components/features/admin/AdminReportList.tsx
+++ b/src/components/features/admin/AdminReportList.tsx
@@ -2,7 +2,7 @@
  * 관리자 신고 목록 컴포넌트
  */
 
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { AlertTriangle, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 
@@ -170,7 +170,7 @@ export function AdminReportList() {
       <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
         {filteredReports.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full">
+            <table className="w-full min-w-[800px]">
               <thead className="bg-neutral-50 border-b border-neutral-200">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">상태</th>
@@ -184,8 +184,8 @@ export function AdminReportList() {
               </thead>
               <tbody className="divide-y divide-neutral-200">
                 {filteredReports.map((report) => (
-                  <>
-                    <tr key={report.id} className="hover:bg-neutral-50">
+                  <Fragment key={report.id}>
+                    <tr className="hover:bg-neutral-50">
                       <td className="px-4 py-3">
                         <span
                           className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
@@ -263,7 +263,7 @@ export function AdminReportList() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 ))}
               </tbody>
             </table>

--- a/src/components/features/admin/AdminSettlementList.tsx
+++ b/src/components/features/admin/AdminSettlementList.tsx
@@ -2,7 +2,7 @@
  * 관리자 정산 목록 컴포넌트
  */
 
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { Wallet, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 
@@ -162,7 +162,7 @@ export function AdminSettlementList() {
   return (
     <div className="space-y-4">
       {/* 요약 카드 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         <div className="bg-white p-4 rounded-lg border border-neutral-200">
           <p className="text-sm text-neutral-500">대기중인 정산</p>
           <p className="text-2xl font-bold text-neutral-900">
@@ -208,7 +208,7 @@ export function AdminSettlementList() {
       <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
         {filteredSettlements.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full">
+            <table className="w-full min-w-[1000px]">
               <thead className="bg-neutral-50 border-b border-neutral-200">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">상태</th>
@@ -223,8 +223,8 @@ export function AdminSettlementList() {
               </thead>
               <tbody className="divide-y divide-neutral-200">
                 {filteredSettlements.map((settlement) => (
-                  <>
-                    <tr key={settlement.id} className="hover:bg-neutral-50">
+                  <Fragment key={settlement.id}>
+                    <tr className="hover:bg-neutral-50">
                       <td className="px-4 py-3">
                         <span
                           className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
@@ -316,7 +316,7 @@ export function AdminSettlementList() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 ))}
               </tbody>
             </table>

--- a/src/components/features/admin/AdminSidebar.tsx
+++ b/src/components/features/admin/AdminSidebar.tsx
@@ -31,7 +31,7 @@ interface AdminSidebarProps {
 
 const AdminSidebar = ({ onClose }: AdminSidebarProps) => {
   return (
-    <aside className="w-64 bg-neutral-900 text-white min-h-screen flex flex-col">
+    <aside className="w-64 bg-neutral-900 text-white h-full flex flex-col">
       {/* 로고 및 닫기 버튼 (모바일) */}
       <div className="p-6 border-b border-neutral-800 flex items-center justify-between">
         <h1 className="text-xl font-bold">

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -13,7 +13,7 @@ const AdminLayout = () => {
   }, [location]);
 
   return (
-    <div className="flex min-h-screen bg-neutral-100">
+    <div className="flex h-screen overflow-hidden bg-neutral-100">
       {/* 사이드바 오버레이 (모바일) */}
       {isSidebarOpen && (
         <div 
@@ -24,7 +24,7 @@ const AdminLayout = () => {
 
       {/* 사이드바 */}
       <div className={`
-        fixed inset-y-0 left-0 z-50 transform lg:relative lg:translate-x-0 transition-transform duration-300
+        fixed inset-y-0 left-0 z-50 transform lg:relative lg:translate-x-0 transition-transform duration-300 h-full
         ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
       `}>
         <AdminSidebar onClose={() => setIsSidebarOpen(false)} />


### PR DESCRIPTION
관리자 레이아웃을 고정형(h-screen)으로 변경하고, 리스트 테이블의 반응형을 강화했습니다.

Closes #46