### PR TITLE
[UI/UX] 홈화면 상품 태그 디자인 개선

### DIFF
--- a/src/components/features/product/ProductCard.tsx
+++ b/src/components/features/product/ProductCard.tsx
@@ -2,12 +2,15 @@ import { Link } from 'react-router-dom';
 import { Card } from '@/components/common/Card';
 import type { Product } from '@/mocks/products';
 import { formatTimeAgo } from '@/utils/date';
+import { SALE_STATUS_LABELS } from '@/constants';
 
 interface ProductCardProps {
   product: Product;
 }
 
 export function ProductCard({ product }: ProductCardProps) {
+  const isUnavailable = product.saleStatus === 'SOLD_OUT' || product.saleStatus === 'RESERVED';
+
   return (
     <Link to={`/products/${product.id}`} className="group block">
       <Card 
@@ -20,19 +23,22 @@ export function ProductCard({ product }: ProductCardProps) {
             src={product.image}
             alt={product.title}
             className={`h-full w-full object-cover transition-transform duration-300 group-hover:scale-110 ${
-              (product.saleStatus === 'SOLD_OUT' || product.saleStatus === 'RESERVED') ? 'grayscale-[0.5]' : ''
+              isUnavailable ? 'brightness-75' : ''
             }`}
             loading="lazy"
           />
-          {/* Status Overlay */}
-          {(product.saleStatus === 'SOLD_OUT' || product.saleStatus === 'RESERVED') && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/40 backdrop-blur-[1px]">
-              <span className={`rounded-md border-2 px-3 py-1 text-sm font-black uppercase tracking-wider ${
-                product.saleStatus === 'SOLD_OUT' 
-                ? 'border-white text-white' 
-                : 'border-yellow-400 text-yellow-400'
-              }`}>
-                {product.saleStatus === 'SOLD_OUT' ? 'Sold Out' : 'Reserved'}
+          {/* Status Overlay - 서비스 톤앤매너에 맞는 한국어 태그 */}
+          {isUnavailable && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center">
+              <span className={`
+                rounded-full px-4 py-1.5 text-sm font-bold shadow-lg
+                backdrop-blur-sm
+                ${product.saleStatus === 'SOLD_OUT' 
+                  ? 'bg-neutral-800/80 text-white' 
+                  : 'bg-primary-500/90 text-white'
+                }
+              `}>
+                {SALE_STATUS_LABELS[product.saleStatus]}
               </span>
             </div>
           )}


### PR DESCRIPTION
## 개요
홈화면 상품 카드의 상태 태그(예약중/품절)를 서비스 톤앤매너에 맞게 개선

## 변경 사항
- 영문 태그(Sold Out/Reserved)  한국어(품절/예약중)
- 박스 스타일  둥근 필(pill) 형태
- Very Peri 기반 컬러 시스템 적용
  - 예약중: primary-500 (보라색) 
  - 품절: neutral-800 (다크)
- 이미지 그레이스케일 제거  밝기 조절로 변경

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
- 상품 카드의 이미지 밝기를 조정하여 구매 불가능한 상품 시각화 개선
- 상태 표시 오버레이를 새로운 배지 스타일로 업데이트
- 품절/예약됨 상태에 따른 구분 색상 강화로 사용자 이해도 향상
- 중앙 정렬된 원형 배지 디자인으로 전반적인 시각적 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->