### PR TITLE
[UI/UX] 거래상태 및 컨디션 도움말 툴팁 추가

### DIFF
--- a/src/components/common/HelpTooltip.tsx
+++ b/src/components/common/HelpTooltip.tsx
@@ -1,0 +1,107 @@
+/**
+ * 도움말 툴팁 컴포넌트
+ * Desktop: hover 시 표시
+ * Mobile: tap 시 표시 (toggle)
+ */
+
+import { useState, useRef, useEffect, type ReactNode } from 'react';
+import { HelpCircle, X } from 'lucide-react';
+
+interface HelpTooltipProps {
+  content: ReactNode;
+  title?: string;
+  className?: string;
+}
+
+export function HelpTooltip({ content, title, className = '' }: HelpTooltipProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (
+        tooltipRef.current &&
+        buttonRef.current &&
+        !tooltipRef.current.contains(event.target as Node) &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('touchstart', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  return (
+    <div className={`relative inline-flex ${className}`}>
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen(!isOpen)}
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
+        className="text-neutral-400 hover:text-neutral-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-full"
+        aria-label="도움말 보기"
+        aria-expanded={isOpen}
+      >
+        <HelpCircle className="h-4 w-4" />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={tooltipRef}
+          role="tooltip"
+          className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 sm:w-72"
+        >
+          <div className="bg-neutral-800 text-white rounded-lg shadow-xl p-3 text-sm">
+            {/* 모바일 닫기 버튼 */}
+            <button
+              onClick={() => setIsOpen(false)}
+              className="md:hidden absolute top-2 right-2 text-neutral-400 hover:text-white"
+              aria-label="닫기"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            
+            {title && (
+              <div className="font-bold text-neutral-100 mb-2 pr-6 md:pr-0">
+                {title}
+              </div>
+            )}
+            <div className="text-neutral-300 leading-relaxed">
+              {content}
+            </div>
+          </div>
+          {/* 화살표 */}
+          <div className="absolute left-1/2 -translate-x-1/2 -bottom-1 w-2 h-2 bg-neutral-800 rotate-45" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -29,6 +29,28 @@ export const CONDITION_STATUS_LABELS: Record<ConditionStatus, string> = {
   DAMAGED: '하자 있음',
 };
 
+/**
+ * 판매상태 도움말 설명
+ */
+export const SALE_STATUS_DESCRIPTIONS: Record<SaleStatus, string> = {
+  ON_SALE: '현재 구매 가능한 상품입니다.',
+  RESERVED: '다른 구매자가 결제를 진행 중인 상품입니다. 구매 확정 전까지는 거래가 취소될 수 있습니다.',
+  SOLD_OUT: '이미 판매가 완료된 상품입니다.',
+  HIDDEN: '판매자가 일시적으로 숨긴 상품입니다.',
+  BLOCKED: '정책 위반으로 차단된 상품입니다.',
+};
+
+/**
+ * 상품 상태(컨디션) 도움말 설명
+ */
+export const CONDITION_STATUS_DESCRIPTIONS: Record<ConditionStatus, string> = {
+  SEALED: '포장이 개봉되지 않은 새 제품입니다.',
+  NO_WEAR: '사용 흔적이 없는 깨끗한 상태입니다.',
+  MINOR_WEAR: '약간의 사용감이 있으나 기능에 문제없습니다.',
+  VISIBLE_WEAR: '눈에 띄는 사용 흔적이 있습니다.',
+  DAMAGED: '부분적인 파손이나 기능 이상이 있습니다.',
+};
+
 export const ORDER_STATUS_LABELS: Record<OrderStatus, { text: string; className: string }> = {
   PENDING: { text: '결제 대기', className: 'bg-yellow-100 text-yellow-700' },
   PAID: { text: '결제 완료', className: 'bg-blue-100 text-blue-700' },

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -19,6 +19,7 @@ import {
   ERROR_MESSAGES, 
   CONDITION_STATUS_LABELS 
 } from '@/constants';
+import { HelpTooltip } from '@/components/common/HelpTooltip';
 
 export default function ProductDetailPage() {
   const { productId: rawProductId } = useParams();
@@ -131,7 +132,7 @@ export default function ProductDetailPage() {
             <div className="border-b border-gray-200 pb-6">
               <div className="mb-4 flex items-start justify-between">
                 <div>
-                   <div className="flex gap-2 mb-2">
+                   <div className="flex items-center gap-2 mb-2">
                     {isSafe && (
                         <span className="inline-flex items-center gap-1 rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
                         <ShieldCheck className="h-3 w-3" />
@@ -147,6 +148,18 @@ export default function ProductDetailPage() {
                     }`}>
                         {CONDITION_STATUS_LABELS[conditionStatus]}
                     </span>
+                    <HelpTooltip 
+                      title="상품 상태란?"
+                      content={
+                        <ul className="space-y-1.5">
+                          <li><strong>미개봉:</strong> 포장이 개봉되지 않은 새 제품</li>
+                          <li><strong>사용감 없음:</strong> 사용 흔적이 없는 깨끗한 상태</li>
+                          <li><strong>사용감 적음:</strong> 약간의 사용감, 기능 문제 없음</li>
+                          <li><strong>사용감 많음:</strong> 눈에 띄는 사용 흔적</li>
+                          <li><strong>하자 있음:</strong> 부분적 파손이나 기능 이상</li>
+                        </ul>
+                      }
+                    />
                    </div>
                   <h1 className="text-2xl font-bold text-gray-900 md:text-3xl">{title}</h1>
                 </div>


### PR DESCRIPTION
## 개요
상품 상세 페이지에서 상품 상태(컨디션)에 대한 도움말 제공

## 변경 사항
- **HelpTooltip.tsx** (신규): 공통 도움말 툴팁 컴포넌트
  - Desktop: hover 시 표시
  - Mobile: tap 시 토글
  - 접근성(ARIA) 지원
  - 외부 클릭 및 ESC 키로 닫기
- **labels.ts**: 상태 도움말 설명 상수 추가
- **ProductDetailPage.tsx**: 컨디션 태그 옆에 도움말 아이콘 추가

Closes #68