### PR TITLE
[기능] 마이페이지 판매 목록 더보기 페이징 추가

### DIFF
--- a/src/components/features/mypage/SalesTabs.tsx
+++ b/src/components/features/mypage/SalesTabs.tsx
@@ -29,13 +29,31 @@ const TABS: { key: TabType; label: string }[] = [
   { key: 'SOLD_OUT', label: '판매완료' },
 ];
 
+const PAGE_SIZE = 5;
+
 const SalesTabs = ({ products }: SalesTabsProps) => {
   const [activeTab, setActiveTab] = useState<TabType>('all');
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const filteredProducts =
     activeTab === 'all'
       ? products
       : products.filter((p) => p.saleStatus === activeTab);
+
+  // 현재 노출할 상품들
+  const visibleProducts = filteredProducts.slice(0, visibleCount);
+  const hasMore = filteredProducts.length > visibleCount;
+
+  // 탭 변경 핸들러 (페이지 초기화)
+  const handleTabChange = (key: TabType) => {
+    setActiveTab(key);
+    setVisibleCount(PAGE_SIZE);
+  };
+
+  // 더보기 클릭
+  const handleShowMore = () => {
+    setVisibleCount((prev) => prev + PAGE_SIZE);
+  };
 
   // 탭별 카운트
   const counts = {
@@ -52,7 +70,7 @@ const SalesTabs = ({ products }: SalesTabsProps) => {
         {TABS.map((tab) => (
           <button
             key={tab.key}
-            onClick={() => setActiveTab(tab.key)}
+            onClick={() => handleTabChange(tab.key)}
             className={`flex-1 py-3 text-sm font-medium transition-colors relative
               ${
                 activeTab === tab.key
@@ -83,9 +101,19 @@ const SalesTabs = ({ products }: SalesTabsProps) => {
           </div>
         ) : (
           <div className="space-y-3">
-            {filteredProducts.map((product) => (
+            {visibleProducts.map((product) => (
               <SalesProductCard key={product.id} product={product} />
             ))}
+            
+            {/* 더보기 버튼 */}
+            {hasMore && (
+              <button
+                onClick={handleShowMore}
+                className="w-full py-3 mt-2 text-sm font-semibold text-neutral-600 border border-neutral-200 rounded-xl hover:bg-neutral-50 transition-colors"
+              >
+                더보기 ({filteredProducts.length - visibleCount})
+              </button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## 개요
사용자의 판매 상품 목록이 길어질 경우를 대비하여 초기 노출 개수를 제한하고, '더보기' 버튼을 통해 점진적으로 노출하도록 개선합니다.

## 변경 사항
- SalesTabs.tsx 컴포넌트에 페이징 로직 추가
- 초기 5개 노출, '더보기' 클릭 시 5개씩 추가 노출
- 탭 변경 시 페이지 수 초기화

Closes #83