### PR TITLE
[기능] 본인 상점 팔로우 방지 및 '내 상점' 뱃지 표시

### DIFF
--- a/src/components/features/shop/ShopHeader.tsx
+++ b/src/components/features/shop/ShopHeader.tsx
@@ -3,13 +3,18 @@
  */
 
 import type { Shop } from '../../../mocks/users';
+import { useAuthStore } from '../../../stores/useAuthStore';
 import FollowButton from './FollowButton';
+import { Store } from 'lucide-react';
 
 interface ShopHeaderProps {
   shop: Shop;
 }
 
 const ShopHeader = ({ shop }: ShopHeaderProps) => {
+  const { user: currentUser } = useAuthStore();
+  const isMyShop = currentUser?.id === shop.userId;
+
   return (
     <div className="bg-white rounded-2xl p-6 border border-neutral-200">
       <div className="flex items-start gap-4">
@@ -30,15 +35,25 @@ const ShopHeader = ({ shop }: ShopHeaderProps) => {
 
         {/* 상점 정보 */}
         <div className="flex-1 min-w-0">
-          <h1 className="text-xl font-bold text-neutral-900 mb-1">{shop.name}</h1>
+          <div className="flex items-center gap-2 mb-1">
+            <h1 className="text-xl font-bold text-neutral-900 truncate">
+              {shop.name}
+            </h1>
+            {isMyShop && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary-50 text-primary-600 text-xs font-bold rounded-full border border-primary-100">
+                <Store className="w-3 h-3" />
+                내 상점
+              </span>
+            )}
+          </div>
           {shop.intro && (
             <p className="text-sm text-neutral-600 line-clamp-2">{shop.intro}</p>
           )}
         </div>
 
-        {/* 팔로우 버튼 */}
+        {/* 액션 버튼 */}
         <div className="flex-shrink-0">
-          <FollowButton shopId={shop.id} />
+          {!isMyShop && <FollowButton shopId={shop.id} />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 개요
본인의 상점 페이지에 접속했을 때 팔로우 버튼 대신 '내 상점'임을 나타내는 UI를 표시하고 팔로우를 방지함.

## 변경 사항
- ShopHeader.tsx에서 로그인 유저와 상점 소유주 ID를 비교하여 UI 분기
- 본인 상점인 경우 '내 상점' 뱃지 표시 및 팔로우 버튼 숨김

Closes #85