### PR TITLE
feat: 동적 인증 및 유저 데이터 바인딩 구현 (#87)

### DIFF
--- a/src/components/features/admin/AdminUserList.tsx
+++ b/src/components/features/admin/AdminUserList.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from 'react';
 import { Search, MoreVertical, User, Ban, CheckCircle } from 'lucide-react';
-import { MOCK_USER, type User as UserType } from '@/mocks/users';
+import { MOCK_USERS_DATA, type User as UserType } from '@/mocks/users';
 
 type UserStatus = 'active' | 'suspended';
 
@@ -12,14 +12,11 @@ interface AdminUser extends UserType {
   status: UserStatus;
 }
 
-// Mock 관리자용 사용자 목록 데이터
-const ADMIN_USERS: AdminUser[] = [
-  { ...MOCK_USER, status: 'active' },
-  { id: 'u2', email: 'user2@example.com', nickname: '캠핑러버', avatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&q=80&w=200', point: 5000, createdAt: '2024-02-10T00:00:00.000Z', status: 'active' },
-  { id: 'u3', email: 'user3@example.com', nickname: '기타맨', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&q=80&w=200', point: 12000, createdAt: '2024-03-05T00:00:00.000Z', status: 'active' },
-  { id: 'u4', email: 'user4@example.com', nickname: '아이돌팬', avatar: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&q=80&w=200', point: 8000, createdAt: '2024-03-15T00:00:00.000Z', status: 'suspended' },
-  { id: 'u5', email: 'user5@example.com', nickname: '오디오덕후', avatar: 'https://images.unsplash.com/photo-1527980965255-d3b416303d12?auto=format&fit=crop&q=80&w=200', point: 20000, createdAt: '2024-04-01T00:00:00.000Z', status: 'active' },
-];
+// Mock 관리자용 사용자 목록 데이터 - MOCK_USERS_DATA에서 상위 5명 가져옴
+const ADMIN_USERS: AdminUser[] = MOCK_USERS_DATA.slice(0, 5).map((u, index) => ({
+  ...u,
+  status: index % 4 === 0 ? 'suspended' : 'active' // 예시를 위해 일부 정지 처리
+}));
 
 const STATUS_LABELS: Record<UserStatus, string> = {
   active: '활성',

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 
 const loginSchema = z.object({
-  email: z.string().email('올바른 이메일 형식을 입력해주세요.'),
+  loginId: z.string().min(1, '아이디를 입력해주세요.'),
   password: z.string().min(6, '비밀번호는 최소 6자 이상이어야 합니다.'),
   autoLogin: z.boolean().optional(),
 });
@@ -15,13 +15,19 @@ type LoginSchema = z.infer<typeof loginSchema>;
 
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/useAuthStore';
-
-// ... (Schema definition remains same)
+import { useToast } from '@/components/common/Toast';
+import { useLikeStore } from '@/stores/useLikeStore';
+import { useFollowStore } from '@/stores/useFollowStore';
+import { useSellerStore } from '@/stores/useSellerStore';
 
 export function LoginForm() {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const { login } = useAuthStore();
+  const { showToast } = useToast();
+  const initUserLikes = useLikeStore((state) => state.initUserLikes);
+  const initFollowing = useFollowStore((state) => state.initFollowing);
+  const initSellerProducts = useSellerStore((state) => state.initSellerProducts);
 
   const {
     register,
@@ -36,35 +42,44 @@ export function LoginForm() {
 
   const onSubmit = async (data: LoginSchema) => {
     setIsLoading(true);
-    // [MOCK] API Call Simulation
-    console.log('[MOCK] Login Request:', data);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     
-    // [MOCK] Login Success
-    login({
-      id: 'mock-user-001',
-      email: data.email,
-      name: 'Mock User',
-    });
-    
-    alert('로그인되었습니다. (Mock)');
-    setIsLoading(false);
-    navigate('/'); // Redirect to Home
+    try {
+      const result = await login(data.loginId, data.password);
+      
+      if (result.success) {
+        // 유저별 초기 데이터(찜, 팔로우) 로드
+        const { user } = useAuthStore.getState();
+        if (user) {
+          initUserLikes(user.id);
+          initFollowing(user.id);
+          initSellerProducts(user.id);
+        }
+        
+        showToast('로그인 성공', 'success');
+        navigate('/');
+      } else {
+        showToast(result.message || 'ID 또는 비밀번호를 확인해주세요.', 'error');
+      }
+    } catch (error) {
+      showToast('로그인 중 문제가 발생했습니다.', 'error');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       <Input
-        label="이메일"
-        type="email"
-        placeholder="example@email.com"
-        error={errors.email?.message}
-        {...register('email')}
+        label="아이디"
+        type="text"
+        placeholder="user1 ~ user20"
+        error={errors.loginId?.message}
+        {...register('loginId')}
       />
       <Input
         label="비밀번호"
         type="password"
-        placeholder="비밀번호를 입력해주세요"
+        placeholder="testuser (테스트용)"
         error={errors.password?.message}
         {...register('password')}
       />

--- a/src/components/features/mypage/FollowingShops.tsx
+++ b/src/components/features/mypage/FollowingShops.tsx
@@ -9,9 +9,15 @@ import { MOCK_SHOPS } from '@/mocks/users';
 import { Button } from '@/components/common/Button';
 import { EmptyState } from '@/components/common/EmptyState';
 
-export function FollowingShops() {
-  const { followingShopIds, removeFollow } = useFollowStore();
+interface FollowingShopsProps {
+  userId: string;
+}
+
+export function FollowingShops({ userId }: FollowingShopsProps) {
+  const { userFollowing, removeFollow } = useFollowStore();
   
+  const followingShopIds = userFollowing[userId] || [];
+
   // 팔로우한 상점 정보 조회
   const followingShops = MOCK_SHOPS.filter((shop) => 
     followingShopIds.includes(shop.id)
@@ -30,7 +36,7 @@ export function FollowingShops() {
   const handleUnfollow = (shopId: string, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    removeFollow(shopId);
+    removeFollow(userId, shopId);
   };
 
   return (

--- a/src/components/features/seller/MyShopInfo.tsx
+++ b/src/components/features/seller/MyShopInfo.tsx
@@ -7,7 +7,7 @@ import { Camera, Save } from 'lucide-react';
 import { Input } from '@/components/common/Input';
 import { Button } from '@/components/common/Button';
 import { useToast } from '@/components/common/Toast';
-import { MOCK_USER } from '@/mocks/users';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface ShopInfo {
   name: string;
@@ -17,12 +17,16 @@ interface ShopInfo {
 
 const MyShopInfo = () => {
   const { showToast } = useToast();
+  const { user } = useAuthStore();
   const [isEditing, setIsEditing] = useState(false);
-  const [shopInfo, setShopInfo] = useState<ShopInfo>({
-    name: MOCK_USER.nickname,
-    intro: MOCK_USER.intro || '',
-    avatar: MOCK_USER.avatar || '',
-  });
+  
+  const initialShopInfo: ShopInfo = {
+    name: user?.nickname || '',
+    intro: user?.intro || '',
+    avatar: user?.avatar || '',
+  };
+
+  const [shopInfo, setShopInfo] = useState<ShopInfo>(initialShopInfo);
   const [editForm, setEditForm] = useState<ShopInfo>(shopInfo);
 
   const handleEdit = () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -108,7 +108,7 @@ export function Header() {
                  <div className="w-6 h-6 rounded-full bg-neutral-300 flex items-center justify-center">
                    <UserIcon className="h-4 w-4 text-white" />
                  </div>
-                 <span className="text-xs font-semibold">{user?.name}님</span>
+                 <span className="text-xs font-semibold">{user?.nickname}님</span>
                </Link>
                <Button 
                   variant="ghost" 
@@ -171,7 +171,7 @@ export function Header() {
                        <UserIcon className="h-6 w-6 text-neutral-500" />
                     </div>
                     <div>
-                      <p className="font-bold">{user?.name}</p>
+                      <p className="font-bold">{user?.nickname}</p>
                       <p className="text-xs text-neutral-500">{user?.email}</p>
                     </div>
                   </div>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -2,11 +2,13 @@
  * 마이페이지 메인
  */
 
+import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useLikeStore } from '../stores/useLikeStore';
 import { useFollowStore } from '../stores/useFollowStore';
-import { MOCK_USER, MOCK_ORDER_HISTORY, MOCK_SALES_PRODUCTS } from '../mocks/users';
+import { useSellerStore } from '../stores/useSellerStore';
+import { MOCK_ORDER_HISTORY } from '../mocks/users';
 
 import ProfileCard from '../components/features/mypage/ProfileCard';
 import ProfileStats from '../components/features/mypage/ProfileStats';
@@ -16,34 +18,53 @@ import MyPageNav from '../components/features/mypage/MyPageNav';
 import { FollowingShops } from '../components/features/mypage/FollowingShops';
 
 const MyPage = () => {
-  const { isAuthenticated } = useAuthStore();
-  const likeCount = useLikeStore((state) => state.getLikedCount());
-  const followingCount = useFollowStore((state) => state.getFollowingCount());
+  const { isAuthenticated, user } = useAuthStore();
+  const likeCount = useLikeStore((state) => state.getLikedCount(user?.id || ''));
+  const followingCount = useFollowStore((state) => state.getFollowingCount(user?.id || ''));
+  const mySalesProducts = useSellerStore((state) => state.products);
+  const initSellerProducts = useSellerStore((state) => state.initSellerProducts);
+  const initUserLikes = useLikeStore((state) => state.initUserLikes);
+  const initFollowing = useFollowStore((state) => state.initFollowing);
+
+  useEffect(() => {
+    if (user?.id) {
+      // 이미 로드된 데이터가 없을 경우에만 초기화하거나, 
+      // 앱 요구사항에 따라 항상 최신 Mock 데이터를 로드하도록 할 수 있음
+      if (mySalesProducts.length === 0) {
+        initSellerProducts(user.id);
+      }
+      initUserLikes(user.id);
+      initFollowing(user.id);
+    }
+  }, [user?.id, initSellerProducts, initUserLikes, initFollowing, mySalesProducts.length]);
 
   // 로그인하지 않은 경우 로그인 페이지로 리다이렉트
-  if (!isAuthenticated) {
+  if (!isAuthenticated || !user) {
     return <Navigate to="/login" replace />;
   }
 
-  // 통계 데이터
-  const salesCount = MOCK_SALES_PRODUCTS.length;
-  const purchaseCount = MOCK_ORDER_HISTORY.length;
+  // 통계 데이터 - 현재 유저 기반 동적 계산
+  // mySalesProducts는 store에서 가져옴
+  const myPurchases = MOCK_ORDER_HISTORY.filter((o) => o.buyerId === user.id);
+  
+  const salesCount = mySalesProducts.length;
+  const purchaseCount = myPurchases.length;
 
   return (
     <div className="min-h-screen bg-neutral-50 py-6 pb-20">
       <div className="max-w-2xl mx-auto px-4 space-y-6">
         {/* 프로필 카드 */}
-        <ProfileCard user={MOCK_USER} />
+        <ProfileCard user={user} />
 
         {/* 통계 */}
         <ProfileStats
           salesCount={salesCount}
           purchaseCount={purchaseCount}
-          point={MOCK_USER.point}
+          point={user.point}
         />
 
         {/* 정산 계좌 */}
-        <SettlementCard user={MOCK_USER} />
+        <SettlementCard user={user} />
 
         {/* 빠른 메뉴 */}
         <MyPageNav likeCount={likeCount} orderCount={purchaseCount} />
@@ -51,7 +72,7 @@ const MyPage = () => {
         {/* 판매 내역 */}
         <div>
           <h2 className="text-lg font-bold text-neutral-900 mb-3">내 판매 상품</h2>
-          <SalesTabs products={MOCK_SALES_PRODUCTS as any} />
+          <SalesTabs products={mySalesProducts as any} />
         </div>
 
         {/* 팔로우한 상점 */}
@@ -59,7 +80,7 @@ const MyPage = () => {
           <h2 className="text-lg font-bold text-neutral-900 mb-3">
             팔로우한 상점 <span className="text-primary-600">{followingCount}</span>
           </h2>
-          <FollowingShops />
+          <FollowingShops userId={user.id} />
         </div>
       </div>
     </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,15 +7,21 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Camera } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { useToast } from '@/components/common/Toast';
-import { MOCK_USER } from '@/mocks/users';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { Navigate } from 'react-router-dom';
 
 const ProfilePage = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { user, isAuthenticated } = useAuthStore();
   
-  const [nickname, setNickname] = useState(MOCK_USER.nickname);
-  const [intro, setIntro] = useState(MOCK_USER.intro || '');
-  const [avatar] = useState(MOCK_USER.avatar);
+  const [nickname, setNickname] = useState(user?.nickname || '');
+  const [intro, setIntro] = useState(user?.intro || '');
+  const [avatar] = useState(user?.avatar || '');
+
+  if (!isAuthenticated || !user) {
+    return <Navigate to="/login" replace />;
+  }
 
   const handleSave = () => {
     showToast('프로필이 수정되었습니다.', 'success');
@@ -92,7 +98,7 @@ const ProfilePage = () => {
             <label className="block text-sm font-medium text-neutral-700 mb-2">이메일</label>
             <input
               type="email"
-              value={MOCK_USER.email}
+              value={user.email}
               disabled
               className="w-full px-4 py-3 border border-neutral-200 rounded-xl bg-neutral-100 text-neutral-500 cursor-not-allowed"
             />
@@ -104,7 +110,7 @@ const ProfilePage = () => {
             <label className="block text-sm font-medium text-neutral-700 mb-2">휴대폰</label>
             <input
               type="tel"
-              value={MOCK_USER.phone || ''}
+              value={user.phone || ''}
               disabled
               className="w-full px-4 py-3 border border-neutral-200 rounded-xl bg-neutral-100 text-neutral-500 cursor-not-allowed"
             />

--- a/src/pages/SettlementAccountPage.tsx
+++ b/src/pages/SettlementAccountPage.tsx
@@ -4,7 +4,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save } from 'lucide-react';
-import { MOCK_USER } from '../mocks/users';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../stores/useAuthStore';
 import { useToast } from '../components/common/Toast';
 
 const BANKS = [
@@ -15,9 +16,14 @@ const BANKS = [
 const SettlementAccountPage = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { user, isAuthenticated } = useAuthStore();
   
+  if (!isAuthenticated || !user) {
+    return <Navigate to="/login" replace />;
+  }
+
   // Mock User의 계좌 정보 또는 빈 값으로 초기화
-  const initialAccount = MOCK_USER.settlementAccount || { bank: '', accountNumber: '', holder: '' };
+  const initialAccount = user.settlementAccount || { bank: '', accountNumber: '', holder: '' };
   
   const [formData, setFormData] = useState({
     bank: initialAccount.bank,

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,72 +1,74 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-
-/**
- * [MOCK] User Interface
- * 나중에 실제 백엔드 API, 타입 정의와 연동 시 교체 필요
- */
-interface User {
-  id: string;
-  email: string;
-  name: string;
-}
+import { MOCK_USERS_DATA, type User } from '../mocks/users';
 
 interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
-  /**
-   * [ADMIN] 관리자 인증 상태
-   * - 현재는 프론트엔드 Mock 처리
-   * - 추후 백엔드 API 연동 시 실제 권한 검사 필요
-   * - 관리자 페이지는 별도 서브도메인으로 분리 예정
-   */
   isAdminAuthenticated: boolean;
-  login: (user: User) => void;
+  
+  /**
+   * [MOCK] 동적 로그인
+   * - loginId: user1, user2, ... user20
+   * - password: testuser
+   */
+  login: (loginId: string, password: string) => Promise<{ success: boolean; message?: string }>;
   logout: () => void;
+  
   /**
    * [MOCK] 관리자 로그인
-   * TODO: API 연동 시 실제 권한 검사 로직으로 교체
    */
   adminLogin: (adminId: string, password: string) => boolean;
   adminLogout: () => void;
 }
 
-/**
- * [MOCK] Auth Store
- * 현재는 클라이언트 측 Mock 데이터로 동작하며, LocalStorage에 상태를 영구 저장합니다.
- * 추후 API 연동 시 login/logout 액션 내부 로직을 API 호출로 변경해야 합니다.
- * 
- * [IMPORTANT] 관리자 인증 관련
- * - isAdminAuthenticated: 관리자 페이지 접근 권한
- * - 현재 Mock 로그인 (admin/admin123)
- * - 추후 백엔드 API 연동 시:
- *   1. 별도 서브도메인(admin.example.com)으로 분리
- *   2. JWT 토큰 기반 권한 검사
- *   3. API 레벨 권한 차단 필수 (프론트엔드만으로는 불충분)
- */
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,
       isAuthenticated: false,
       isAdminAuthenticated: false,
-      login: (user) => set({ user, isAuthenticated: true }),
+      
+      login: async (loginId: string, password: string) => {
+        // [MOCK] 인증 시뮬레이션
+        await new Promise(resolve => setTimeout(resolve, 800));
+
+        // password 검제
+        if (password !== 'testuser') {
+          return { success: false, message: '비밀번호가 일치하지 않습니다. (testuser 입력 필요)' };
+        }
+
+        // user1, user2 패턴 분석하여 인덱스 추출
+        const match = loginId.match(/^user(\d+)$/);
+        if (!match) {
+          return { success: false, message: 'ID 형식이 올바르지 않습니다. (user1 ~ user20)' };
+        }
+
+        const index = parseInt(match[1], 10) - 1;
+        const targetUser = MOCK_USERS_DATA[index];
+
+        if (!targetUser) {
+          return { success: false, message: '존재하지 않는 사용자입니다.' };
+        }
+
+        set({ user: targetUser, isAuthenticated: true });
+        return { success: true };
+      },
+
       logout: () => set({ user: null, isAuthenticated: false, isAdminAuthenticated: false }),
+
       adminLogin: (adminId: string, password: string) => {
-        // [MOCK] 하드코딩된 관리자 계정
-        // TODO: 추후 API 연동 시 실제 인증 로직으로 교체 필요
         if (adminId === 'admin' && password === 'admin123') {
           set({ isAdminAuthenticated: true });
-          console.log('[MOCK] Admin login successful');
           return true;
         }
-        console.log('[MOCK] Admin login failed - invalid credentials');
         return false;
       },
+      
       adminLogout: () => set({ isAdminAuthenticated: false }),
     }),
     {
-      name: 'auth-storage', // LocalStorage Key
+      name: 'auth-storage',
       storage: createJSONStorage(() => localStorage),
     }
   )

--- a/src/stores/useSellerStore.ts
+++ b/src/stores/useSellerStore.ts
@@ -3,8 +3,7 @@
  */
 
 import { create } from 'zustand';
-import type { SaleStatus, ConditionStatus } from '@/mocks/products';
-import { MOCK_SALES_PRODUCTS } from '@/mocks/users';
+import { MOCK_PRODUCTS, type SaleStatus, type ConditionStatus } from '@/mocks/products';
 
 // 상품 등록/수정 폼 데이터
 export interface ProductFormData {
@@ -55,6 +54,7 @@ interface SellerState {
   deleteProduct: (id: string) => void;
   updateSaleStatus: (id: string, status: SaleStatus) => void;
   updateTrackingInfo: (id: string, info: { number: string; company: string }) => void;
+  initSellerProducts: (userId: string) => void;
   
   // Getters
   getProductById: (id: string) => SellerProduct | undefined;
@@ -71,12 +71,8 @@ interface SellerState {
 }
 
 export const useSellerStore = create<SellerState>((set, get) => ({
-  // 초기 Mock 데이터
-  products: MOCK_SALES_PRODUCTS.map(p => ({
-    ...p,
-    conditionStatus: p.conditionStatus as ConditionStatus,
-    saleStatus: p.saleStatus as SaleStatus,
-  })) as SellerProduct[],
+  // 초기 상태는 빈 배열, 로그인 시 initSellerProducts 호출로 채워짐
+  products: [],
   
   /**
    * 상품 등록
@@ -166,6 +162,18 @@ export const useSellerStore = create<SellerState>((set, get) => ({
           : p
       ),
     }));
+  }, // Added missing comma here
+  /**
+   * 유저별 판매 상품 초기화
+   */
+  initSellerProducts: (userId: string) => {
+    const userProducts = MOCK_PRODUCTS.filter(p => p.seller.userId === userId);
+    set({
+      products: userProducts.map(p => ({
+        ...p,
+        // SellerProduct 인터페이스에 맞게 변환 (필요한 경우)
+      })) as SellerProduct[]
+    });
   },
   
   /**


### PR DESCRIPTION
하드코딩된 MOCK_USER 의존성을 제거하고 동적 인증 시스템을 성공적으로 구축했습니다. 주요 변경 사항으로 useAuthStore 고도화와 각 저장소(찜, 팔로우, 판매자 등)의 유저별 격리 및 초기화 로직을 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 로그인 인증 방식을 이메일에서 사용자 ID 기반으로 변경
  * 로그인 성공/실패에 대한 토스트 알림 추가
  * 팔로우 및 좋아요 데이터 영속성 추가

* **개선 사항**
  * 보호된 페이지에 인증 확인 추가
  * 사용자 프로필 표시명이 닉네임으로 변경
  * 사용자별 맞춤형 데이터 초기화 및 관리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->