### PR TITLE
[수정] 모바일 메뉴 드로어 배경 및 배너 레이아웃 개선

### DIFF
--- a/src/components/features/home/HeroBanner.tsx
+++ b/src/components/features/home/HeroBanner.tsx
@@ -146,23 +146,34 @@ export function HeroBanner() {
             </div>
 
             {/* Content Container */}
-            <div className="container mx-auto px-4 relative z-10 py-10 md:py-14 lg:py-16">
-              <div className="flex flex-col items-center gap-10 md:flex-row md:gap-16">
-                <div className={`flex-1 space-y-5 text-center md:text-left
+            <div className="container mx-auto px-4 relative z-10 py-6 min-[360px]:py-8 md:py-14 lg:py-16">
+              <div className="flex flex-col items-center gap-4 min-[360px]:gap-6 md:flex-row md:gap-16">
+                {/* 모바일에서 split 타입일 때 이미지를 상단에 먼저 표시 */}
+                {banner.imageAlign === 'split' && (
+                  <div className="w-full max-w-[200px] min-[360px]:max-w-[240px] min-[480px]:max-w-[280px] md:hidden mx-auto">
+                    <img 
+                      src={banner.image} 
+                      alt="배너 이미지" 
+                      className="w-full h-auto object-contain drop-shadow-lg"
+                    />
+                  </div>
+                )}
+
+                <div className={`flex-1 space-y-3 min-[360px]:space-y-4 md:space-y-5 text-center md:text-left
                   ${banner.imageAlign === 'full' ? 'max-w-xl' : 'md:max-w-[48%]'}`}>
                   <h1 className={`text-xl min-[360px]:text-2xl min-[480px]:text-3xl font-black leading-[1.2] tracking-tight md:text-4xl lg:text-6xl
                     ${banner.imageAlign === 'full' ? 'text-white' : 'text-neutral-900'}`}>
                     {banner.title}
                   </h1>
-                  <p className={`whitespace-pre-line text-sm min-[360px]:text-base md:text-lg opacity-90 leading-relaxed
+                  <p className={`whitespace-pre-line text-xs min-[360px]:text-sm min-[480px]:text-base md:text-lg opacity-90 leading-relaxed
                     ${banner.imageAlign === 'full' ? 'text-neutral-200' : 'text-neutral-600'}`}>
                     {banner.description}
                   </p>
-                  <div className="flex justify-center gap-4 md:justify-start">
+                  <div className="flex justify-center gap-4 md:justify-start pt-1 min-[360px]:pt-2">
                     <Link to={banner.ctaLink}>
                       <Button 
                         size="lg" 
-                        className={`font-bold ${
+                        className={`font-bold text-sm min-[360px]:text-base ${
                           banner.imageAlign === 'full' 
                             ? 'bg-white text-neutral-900 hover:bg-neutral-100' 
                             : ''
@@ -174,13 +185,16 @@ export function HeroBanner() {
                   </div>
                 </div>
                 
-                <div className="flex-1 w-full md:hidden">
-                  <img 
-                    src={banner.image} 
-                    alt="배너 이미지" 
-                    className="rounded-2xl shadow-xl object-cover aspect-video w-full"
-                  />
-                </div>
+                {/* full 타입 배너의 모바일 이미지 (하단에 표시) */}
+                {banner.imageAlign === 'full' && (
+                  <div className="flex-1 w-full md:hidden">
+                    <img 
+                      src={banner.image} 
+                      alt="배너 이미지" 
+                      className="rounded-2xl shadow-xl object-cover aspect-video w-full"
+                    />
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -159,8 +159,11 @@ export function Header() {
 
       {/* Mobile Menu Drawer */}
       {isMenuOpen && (
-        <div className="fixed inset-0 z-50 bg-black/50 md:hidden">
-          <div className="absolute top-0 right-0 h-full w-[80%] max-w-[300px] bg-white shadow-xl animate-in slide-in-from-right">
+        <div className="fixed inset-0 z-[100] bg-black/70 md:hidden" onClick={() => setIsMenuOpen(false)}>
+          <div 
+            className="absolute top-0 right-0 h-full w-[85%] max-w-[320px] bg-white shadow-2xl animate-in slide-in-from-right"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between p-4 border-b border-neutral-100">
               <h2 className="text-lg font-bold">메뉴</h2>
               <button onClick={() => setIsMenuOpen(false)}>


### PR DESCRIPTION
## 변경 사항
- 모바일 메뉴 드로어 배경 불투명도 70%로 증가 (이전: 50%)
- z-index를 100으로 높여 배너 이미지가 가려지도록 수정
- 배경 영역 클릭 시 메뉴 닫기 기능 추가
- split 타입 배너의 모바일 이미지를 상단에 배치 (object-contain)
- 폰트 크기 및 간격 추가 세분화

## 테스트
- [x] 빌드 성공
- [x] Galaxy Fold (280px) 시뮬레이션 테스트
- [x] iPhone SE (320px) 시뮬레이션 테스트
- [x] 메뉴 드로어 배경 가림 확인
- [x] 배너 이미지 레이아웃 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항

* **배너 레이아웃** - 모바일 및 데스크톱 화면에 맞춘 반응형 디자인 개선으로 다양한 기기에서 최적의 표시 제공
* **모바일 메뉴** - 메뉴 드로어의 오버레이 및 터치 상호작용 개선으로 더 나은 사용자 경험 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->