### PR TITLE
[기능] 어드민 배너 관리 시스템 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ const CategoryManagePage = lazy(() => import('./pages/admin/CategoryManagePage')
 const ReportManagePage = lazy(() => import('./pages/admin/ReportManagePage'));
 const CouponManagePage = lazy(() => import('./pages/admin/CouponManagePage'));
 const SettlementManagePage = lazy(() => import('./pages/admin/SettlementManagePage'));
+const BannerManagePage = lazy(() => import('./pages/admin/BannerManagePage'));
 
 import { ToastProvider } from '@/components/common/Toast';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
@@ -94,6 +95,7 @@ function App() {
               <Route path="admin" element={<AdminAuthGuard />}>
                 <Route element={<AdminLayout />}>
                   <Route index element={<AdminDashboardPage />} />
+                  <Route path="banners" element={<BannerManagePage />} />
                   <Route path="products" element={<ProductManagePage />} />
                   <Route path="users" element={<UserManagePage />} />
                   <Route path="reports" element={<ReportManagePage />} />

--- a/src/components/features/admin/AdminSidebar.tsx
+++ b/src/components/features/admin/AdminSidebar.tsx
@@ -11,11 +11,13 @@ import {
   AlertTriangle,
   Ticket,
   Wallet,
-  LogOut
+  LogOut,
+  Image
 } from 'lucide-react';
 
 const navItems = [
   { icon: LayoutDashboard, label: '대시보드', href: '/admin' },
+  { icon: Image, label: '배너 관리', href: '/admin/banners' },
   { icon: Package, label: '상품 관리', href: '/admin/products' },
   { icon: Users, label: '회원 관리', href: '/admin/users' },
   { icon: AlertTriangle, label: '신고 관리', href: '/admin/reports' },
@@ -23,6 +25,7 @@ const navItems = [
   { icon: Wallet, label: '정산 관리', href: '/admin/settlements' },
   { icon: FolderTree, label: '카테고리 관리', href: '/admin/categories' },
 ];
+
 
 interface AdminSidebarProps {
   isOpen?: boolean;

--- a/src/components/features/home/HeroBanner.tsx
+++ b/src/components/features/home/HeroBanner.tsx
@@ -3,7 +3,7 @@ import type { TouchEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/common/Button';
-import bannerImg from '@/assets/sample_banner_thumbnail.png';
+import { useBannerStore } from '@/stores/useBannerStore';
 
 // 배너 설정 (하드코딩 방지)
 const BANNER_CONFIG = {
@@ -11,70 +11,10 @@ const BANNER_CONFIG = {
   TRANSITION_SPEED: 500,
 } as const;
 
-interface Banner {
-  id: number;
-  title: React.ReactNode;
-  description: string;
-  image: string;
-  imageAlign: 'split' | 'full'; // 분할형(기존) 또는 전체 채우기형
-  imageFit?: 'cover' | 'contain'; // 이미지 채우기 방식 추가
-  bgColor: string;
-  ctaText: string;
-  ctaLink: string;
-}
-
-const BANNERS: Banner[] = [
-  {
-    id: 1,
-    title: (
-      <>
-        취향을 잇는<br />
-        <span className="text-primary-600">중고거래</span>의 시작
-      </>
-    ),
-    description: '캠핑부터 악기까지, 당신만의 라이프스타일을 찾아보세요.\n안전하고 편리한 거래 경험을 제공합니다.',
-    image: bannerImg,
-    imageAlign: 'split',
-    imageFit: 'contain',
-    bgColor: 'from-primary-50 to-primary-100',
-    ctaText: '거래 시작하기',
-    ctaLink: '/seller/products/new'
-  },
-  {
-    id: 2,
-    title: (
-      <>
-        안전한 거래,<br />
-        <span className="text-blue-600">덕쿠</span>와 함께
-      </>
-    ),
-    description: '검증된 판매자와 안전한 결제 시스템으로\n걱정 없는 중고거래를 시작하세요.',
-    image: 'https://images.unsplash.com/photo-1556740738-b6a63e27c4df?auto=format&fit=crop&q=80&w=1000',
-    imageAlign: 'split',
-    imageFit: 'cover',
-    bgColor: 'from-blue-50 to-blue-100',
-    ctaText: '상세 보기',
-    ctaLink: '#'
-  },
-  {
-    id: 3,
-    title: (
-      <span className="text-white">
-        잊고 있던<br />
-        나만의 취미를 찾다
-      </span>
-    ),
-    description: '악기부터 레트로 가전, 수집품까지.\n당신의 열정을 깨울 새로운 취미를 발견하세요.',
-    image: 'https://images.unsplash.com/photo-1516280440614-37939bbacd81?auto=format&fit=crop&q=80&w=1500',
-    imageAlign: 'full',
-    imageFit: 'cover',
-    bgColor: 'from-neutral-900 to-neutral-800',
-    ctaText: '취미 찾으러 가기',
-    ctaLink: '#'
-  }
-];
-
 export function HeroBanner() {
+  const { getBannersForDisplay } = useBannerStore();
+  const banners = getBannersForDisplay();
+  
   const [currentIndex, setCurrentIndex] = useState(0);
   const [touchStart, setTouchStart] = useState<number | null>(null);
   const [touchEnd, setTouchEnd] = useState<number | null>(null);
@@ -83,12 +23,12 @@ export function HeroBanner() {
   const minSwipeDistance = 50;
 
   const handleNext = useCallback(() => {
-    setCurrentIndex((prev) => (prev + 1) % BANNERS.length);
-  }, []);
+    setCurrentIndex((prev) => (prev + 1) % banners.length);
+  }, [banners.length]);
 
   const handlePrev = useCallback(() => {
-    setCurrentIndex((prev) => (prev - 1 + BANNERS.length) % BANNERS.length);
-  }, []);
+    setCurrentIndex((prev) => (prev - 1 + banners.length) % banners.length);
+  }, [banners.length]);
 
   // 터치 이벤트 핸들러 (모바일 스와이프)
   const onTouchStart = (e: TouchEvent) => {
@@ -119,8 +59,8 @@ export function HeroBanner() {
     return () => clearInterval(timer);
   }, [handleNext]);
 
-  const currentBanner = BANNERS[currentIndex];
-  const isDark = currentBanner.imageAlign === 'full';
+  const currentBanner = banners[currentIndex] || banners[0];
+  const isDark = currentBanner?.imageAlign === 'full';
 
   return (
     <section 
@@ -134,7 +74,7 @@ export function HeroBanner() {
         className="flex transition-transform duration-500 ease-out"
         style={{ transform: `translateX(-${currentIndex * 100}%)` }}
       >
-        {BANNERS.map((banner) => (
+        {banners.map((banner) => (
           <div 
             key={banner.id}
             className={`relative min-w-full flex-shrink-0 ${banner.imageAlign === 'split' ? `bg-gradient-to-br ${banner.bgColor}` : ''}`}
@@ -302,7 +242,7 @@ export function HeroBanner() {
 
       {/* 하단 인디케이터 */}
       <div className="absolute bottom-3 min-[360px]:bottom-4 md:bottom-8 left-1/2 flex -translate-x-1/2 gap-2 min-[360px]:gap-3 z-20">
-        {BANNERS.map((_, index) => (
+        {banners.map((_: unknown, index: number) => (
           <button
             key={index}
             onClick={() => setCurrentIndex(index)}

--- a/src/mocks/banners.ts
+++ b/src/mocks/banners.ts
@@ -1,0 +1,68 @@
+/**
+ * 배너 Mock 데이터
+ */
+
+import type { Banner } from '@/types/banner';
+import bannerImg from '@/assets/sample_banner_thumbnail.png';
+
+// 디폴트 배너 (배너가 없을 때 표시)
+export const DEFAULT_BANNER: Banner = {
+  id: 'default',
+  title: '덕쿠에 오신 것을 환영합니다',
+  description: '취미 중고거래의 새로운 시작.\n지금 바로 거래를 시작해보세요.',
+  image: bannerImg,
+  imageAlign: 'split',
+  imageFit: 'contain',
+  bgColor: 'from-primary-50 to-primary-100',
+  ctaText: '둘러보기',
+  ctaLink: '/',
+  order: 0,
+  isActive: true,
+  createdAt: new Date().toISOString(),
+};
+
+// 초기 배너 데이터
+export const MOCK_BANNERS: Banner[] = [
+  {
+    id: 'banner-1',
+    title: '취향을 잇는 중고거래의 시작',
+    description: '캠핑부터 악기까지, 당신만의 라이프스타일을 찾아보세요.\n안전하고 편리한 거래 경험을 제공합니다.',
+    image: bannerImg,
+    imageAlign: 'split',
+    imageFit: 'contain',
+    bgColor: 'from-primary-50 to-primary-100',
+    ctaText: '거래 시작하기',
+    ctaLink: '/seller/products/new',
+    order: 1,
+    isActive: true,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 'banner-2',
+    title: '안전한 거래, 덕쿠와 함께',
+    description: '검증된 판매자와 안전한 결제 시스템으로\n걱정 없는 중고거래를 시작하세요.',
+    image: 'https://images.unsplash.com/photo-1556740738-b6a63e27c4df?auto=format&fit=crop&q=80&w=1000',
+    imageAlign: 'split',
+    imageFit: 'cover',
+    bgColor: 'from-blue-50 to-blue-100',
+    ctaText: '상세 보기',
+    ctaLink: '#',
+    order: 2,
+    isActive: true,
+    createdAt: '2025-01-02T00:00:00Z',
+  },
+  {
+    id: 'banner-3',
+    title: '잊고 있던 나만의 취미를 찾다',
+    description: '악기부터 레트로 가전, 수집품까지.\n당신의 열정을 깨울 새로운 취미를 발견하세요.',
+    image: 'https://images.unsplash.com/photo-1516280440614-37939bbacd81?auto=format&fit=crop&q=80&w=1500',
+    imageAlign: 'full',
+    imageFit: 'cover',
+    bgColor: 'from-neutral-900 to-neutral-800',
+    ctaText: '취미 찾으러 가기',
+    ctaLink: '#',
+    order: 3,
+    isActive: true,
+    createdAt: '2025-01-03T00:00:00Z',
+  },
+];

--- a/src/pages/admin/BannerManagePage.tsx
+++ b/src/pages/admin/BannerManagePage.tsx
@@ -1,0 +1,301 @@
+/**
+ * 관리자 배너 관리 페이지
+ */
+
+import { useState } from 'react';
+import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Eye, EyeOff, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/common/Button';
+import { Modal } from '@/components/common/Modal';
+import { Input } from '@/components/common/Input';
+import { useBannerStore } from '@/stores/useBannerStore';
+import type { Banner, BannerInput, BannerImageAlign, BannerImageFit } from '@/types/banner';
+
+const BannerManagePage = () => {
+  const { banners, addBanner, updateBanner, deleteBanner, toggleBannerActive, moveBannerUp, moveBannerDown, resetToDefault } = useBannerStore();
+  
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingBanner, setEditingBanner] = useState<Banner | null>(null);
+  const [formData, setFormData] = useState<BannerInput>({
+    title: '',
+    description: '',
+    image: '',
+    imageAlign: 'split',
+    imageFit: 'contain',
+    bgColor: 'from-primary-50 to-primary-100',
+    ctaText: '',
+    ctaLink: '',
+  });
+  
+  const sortedBanners = [...banners].sort((a, b) => a.order - b.order);
+  
+  const handleOpenCreate = () => {
+    setEditingBanner(null);
+    setFormData({
+      title: '',
+      description: '',
+      image: '',
+      imageAlign: 'split',
+      imageFit: 'contain',
+      bgColor: 'from-primary-50 to-primary-100',
+      ctaText: '',
+      ctaLink: '',
+    });
+    setIsModalOpen(true);
+  };
+  
+  const handleOpenEdit = (banner: Banner) => {
+    setEditingBanner(banner);
+    setFormData({
+      title: banner.title,
+      description: banner.description,
+      image: banner.image,
+      imageAlign: banner.imageAlign,
+      imageFit: banner.imageFit,
+      bgColor: banner.bgColor,
+      ctaText: banner.ctaText,
+      ctaLink: banner.ctaLink,
+    });
+    setIsModalOpen(true);
+  };
+  
+  const handleSubmit = () => {
+    if (editingBanner) {
+      updateBanner(editingBanner.id, formData);
+    } else {
+      addBanner(formData);
+    }
+    setIsModalOpen(false);
+  };
+  
+  const handleDelete = (id: string) => {
+    if (confirm('정말로 이 배너를 삭제하시겠습니까?')) {
+      deleteBanner(id);
+    }
+  };
+  
+  const bgColorOptions = [
+    { value: 'from-primary-50 to-primary-100', label: '보라색' },
+    { value: 'from-blue-50 to-blue-100', label: '파란색' },
+    { value: 'from-green-50 to-green-100', label: '초록색' },
+    { value: 'from-orange-50 to-orange-100', label: '주황색' },
+    { value: 'from-neutral-900 to-neutral-800', label: '어두운색' },
+  ];
+  
+  return (
+    <div>
+      {/* 페이지 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900">배너 관리</h1>
+          <p className="text-neutral-500 mt-1">홈 화면 롤링 배너를 관리합니다</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={resetToDefault}>
+            <RotateCcw className="w-4 h-4 mr-2" />
+            초기화
+          </Button>
+          <Button onClick={handleOpenCreate}>
+            <Plus className="w-4 h-4 mr-2" />
+            배너 추가
+          </Button>
+        </div>
+      </div>
+      
+      {/* 배너 목록 */}
+      <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-neutral-50 border-b border-neutral-200">
+            <tr>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">순서</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">이미지</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">제목</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">타입</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">상태</th>
+              <th className="px-4 py-3 text-right text-sm font-medium text-neutral-600">관리</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedBanners.map((banner, index) => (
+              <tr key={banner.id} className="border-b border-neutral-100 hover:bg-neutral-50">
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-1">
+                    <span className="text-sm font-medium text-neutral-900">{banner.order}</span>
+                    <div className="flex flex-col ml-2">
+                      <button 
+                        onClick={() => moveBannerUp(banner.id)}
+                        disabled={index === 0}
+                        className="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-30"
+                      >
+                        <ChevronUp className="w-4 h-4" />
+                      </button>
+                      <button 
+                        onClick={() => moveBannerDown(banner.id)}
+                        disabled={index === sortedBanners.length - 1}
+                        className="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-30"
+                      >
+                        <ChevronDown className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <img 
+                    src={banner.image} 
+                    alt={banner.title}
+                    className="w-20 h-12 object-cover rounded"
+                  />
+                </td>
+                <td className="px-4 py-3">
+                  <p className="text-sm font-medium text-neutral-900 truncate max-w-[200px]">{banner.title}</p>
+                  <p className="text-xs text-neutral-500 truncate max-w-[200px]">{banner.description}</p>
+                </td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex px-2 py-1 text-xs font-medium rounded ${
+                    banner.imageAlign === 'full' 
+                      ? 'bg-neutral-100 text-neutral-700' 
+                      : 'bg-primary-100 text-primary-700'
+                  }`}>
+                    {banner.imageAlign === 'full' ? '전체' : '분할'}
+                  </span>
+                  <span className={`ml-1 inline-flex px-2 py-1 text-xs font-medium rounded ${
+                    banner.imageFit === 'cover' 
+                      ? 'bg-blue-100 text-blue-700' 
+                      : 'bg-green-100 text-green-700'
+                  }`}>
+                    {banner.imageFit === 'cover' ? 'cover' : 'contain'}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <button 
+                    onClick={() => toggleBannerActive(banner.id)}
+                    className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded ${
+                      banner.isActive
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-neutral-100 text-neutral-500'
+                    }`}
+                  >
+                    {banner.isActive ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
+                    {banner.isActive ? '활성' : '비활성'}
+                  </button>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button variant="ghost" size="sm" onClick={() => handleOpenEdit(banner)}>
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => handleDelete(banner.id)}>
+                      <Trash2 className="w-4 h-4 text-red-500" />
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {banners.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-neutral-500">
+                  등록된 배너가 없습니다. 배너를 추가해주세요.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      
+      {/* 배너 추가/수정 모달 */}
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title={editingBanner ? '배너 수정' : '배너 추가'}
+      >
+        <div className="space-y-4">
+          <Input
+            label="제목"
+            value={formData.title}
+            onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+            placeholder="배너 제목을 입력하세요"
+          />
+          
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">설명</label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              placeholder="배너 설명을 입력하세요 (줄바꿈: \n)"
+              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              rows={3}
+            />
+          </div>
+          
+          <Input
+            label="이미지 URL"
+            value={formData.image}
+            onChange={(e) => setFormData({ ...formData, image: e.target.value })}
+            placeholder="https://..."
+          />
+          
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 mb-1">레이아웃</label>
+              <select
+                value={formData.imageAlign}
+                onChange={(e) => setFormData({ ...formData, imageAlign: e.target.value as BannerImageAlign })}
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                <option value="split">분할 (split)</option>
+                <option value="full">전체 (full)</option>
+              </select>
+            </div>
+            
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 mb-1">이미지 채우기</label>
+              <select
+                value={formData.imageFit}
+                onChange={(e) => setFormData({ ...formData, imageFit: e.target.value as BannerImageFit })}
+                className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                <option value="contain">원본 비율 (contain)</option>
+                <option value="cover">채우기 (cover)</option>
+              </select>
+            </div>
+          </div>
+          
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">배경색</label>
+            <select
+              value={formData.bgColor}
+              onChange={(e) => setFormData({ ...formData, bgColor: e.target.value })}
+              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              {bgColorOptions.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+          
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              label="버튼 텍스트"
+              value={formData.ctaText}
+              onChange={(e) => setFormData({ ...formData, ctaText: e.target.value })}
+              placeholder="거래 시작하기"
+            />
+            
+            <Input
+              label="버튼 링크"
+              value={formData.ctaLink}
+              onChange={(e) => setFormData({ ...formData, ctaLink: e.target.value })}
+              placeholder="/seller/products/new"
+            />
+          </div>
+          
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={() => setIsModalOpen(false)}>취소</Button>
+            <Button onClick={handleSubmit}>{editingBanner ? '수정' : '추가'}</Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default BannerManagePage;

--- a/src/stores/useBannerStore.ts
+++ b/src/stores/useBannerStore.ts
@@ -1,0 +1,129 @@
+/**
+ * 배너 상태 관리 Store
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Banner, BannerInput } from '@/types/banner';
+import { MOCK_BANNERS, DEFAULT_BANNER } from '@/mocks/banners';
+
+interface BannerStore {
+  banners: Banner[];
+  
+  // 활성 배너 목록 (order 순 정렬)
+  getActiveBanners: () => Banner[];
+  
+  // 배너가 없을 때 디폴트 배너 반환
+  getBannersForDisplay: () => Banner[];
+  
+  // CRUD
+  addBanner: (input: BannerInput) => void;
+  updateBanner: (id: string, input: Partial<BannerInput>) => void;
+  deleteBanner: (id: string) => void;
+  
+  // 활성화/비활성화
+  toggleBannerActive: (id: string) => void;
+  
+  // 순서 변경
+  reorderBanner: (id: string, newOrder: number) => void;
+  moveBannerUp: (id: string) => void;
+  moveBannerDown: (id: string) => void;
+  
+  // 초기화
+  resetToDefault: () => void;
+}
+
+export const useBannerStore = create<BannerStore>()(
+  persist(
+    (set, get) => ({
+      banners: [...MOCK_BANNERS],
+      
+      getActiveBanners: () => {
+        return get().banners
+          .filter(b => b.isActive)
+          .sort((a, b) => a.order - b.order);
+      },
+      
+      getBannersForDisplay: () => {
+        const active = get().getActiveBanners();
+        return active.length > 0 ? active : [DEFAULT_BANNER];
+      },
+      
+      addBanner: (input) => {
+        const banners = get().banners;
+        const maxOrder = Math.max(0, ...banners.map(b => b.order));
+        const newBanner: Banner = {
+          id: `banner-${Date.now()}`,
+          ...input,
+          order: maxOrder + 1,
+          isActive: input.isActive ?? true,
+          createdAt: new Date().toISOString(),
+        };
+        set({ banners: [...banners, newBanner] });
+      },
+      
+      updateBanner: (id, input) => {
+        set({
+          banners: get().banners.map(b =>
+            b.id === id
+              ? { ...b, ...input, updatedAt: new Date().toISOString() }
+              : b
+          ),
+        });
+      },
+      
+      deleteBanner: (id) => {
+        set({ banners: get().banners.filter(b => b.id !== id) });
+      },
+      
+      toggleBannerActive: (id) => {
+        set({
+          banners: get().banners.map(b =>
+            b.id === id ? { ...b, isActive: !b.isActive } : b
+          ),
+        });
+      },
+      
+      reorderBanner: (id, newOrder) => {
+        set({
+          banners: get().banners.map(b =>
+            b.id === id ? { ...b, order: newOrder } : b
+          ),
+        });
+      },
+      
+      moveBannerUp: (id) => {
+        const banners = [...get().banners].sort((a, b) => a.order - b.order);
+        const index = banners.findIndex(b => b.id === id);
+        if (index > 0) {
+          const prev = banners[index - 1];
+          const curr = banners[index];
+          const prevOrder = prev.order;
+          prev.order = curr.order;
+          curr.order = prevOrder;
+          set({ banners });
+        }
+      },
+      
+      moveBannerDown: (id) => {
+        const banners = [...get().banners].sort((a, b) => a.order - b.order);
+        const index = banners.findIndex(b => b.id === id);
+        if (index < banners.length - 1) {
+          const next = banners[index + 1];
+          const curr = banners[index];
+          const nextOrder = next.order;
+          next.order = curr.order;
+          curr.order = nextOrder;
+          set({ banners });
+        }
+      },
+      
+      resetToDefault: () => {
+        set({ banners: [...MOCK_BANNERS] });
+      },
+    }),
+    {
+      name: 'dukku-banner-storage',
+    }
+  )
+);

--- a/src/types/banner.ts
+++ b/src/types/banner.ts
@@ -1,0 +1,35 @@
+/**
+ * 배너 타입 정의
+ */
+
+export type BannerImageAlign = 'split' | 'full';
+export type BannerImageFit = 'cover' | 'contain';
+
+export interface Banner {
+  id: string;
+  title: string;
+  description: string;
+  image: string;
+  imageAlign: BannerImageAlign;
+  imageFit: BannerImageFit;
+  bgColor: string;
+  ctaText: string;
+  ctaLink: string;
+  order: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+// 어드민에서 배너 생성/수정 시 사용
+export interface BannerInput {
+  title: string;
+  description: string;
+  image: string;
+  imageAlign: BannerImageAlign;
+  imageFit: BannerImageFit;
+  bgColor: string;
+  ctaText: string;
+  ctaLink: string;
+  isActive?: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,6 @@ export type { ShopReview } from './review';
 
 // 장바구니 관련
 export type { CartItem, CartSummary } from './cart';
+
+// 배너 관련
+export type { Banner, BannerInput, BannerImageAlign, BannerImageFit } from './banner';


### PR DESCRIPTION
## 개요
어드민 페이지에서 롤링 배너를 관리할 수 있는 시스템을 구현합니다.

## 변경 사항
- 	ypes/banner.ts: 배너 타입 정의
- mocks/banners.ts: 배너 Mock 데이터 및 디폴트 배너
- stores/useBannerStore.ts: Zustand 배너 Store (CRUD, 순서 변경, 활성화/비활성화)
- pages/admin/BannerManagePage.tsx: 어드민 배너 관리 페이지
- HeroBanner.tsx: Store 연동 및 디폴트 배너 처리
- AdminSidebar에 배너 관리 메뉴 추가
- App.tsx 라우팅 추가

## 테스트
- [x] 빌드 성공
- [x] 어드민 배너 목록 표시
- [x] 배너 추가/수정 모달
- [x] 활성/비활성 토글
- [x] 순서 변경
- [x] 홈 배너 정상 표시

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 관리자 배너 관리 페이지 추가 - 배너 생성, 편집, 삭제, 순서 변경, 활성화/비활성화 기능 제공
* 동적 배너 시스템 도입 - 홈페이지 배너가 실시간으로 관리 가능하도록 변경
* 관리자 메뉴에 배너 관리 링크 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->