### PR TITLE
[개선] 배너 관리 페이지 UX 개선

### DIFF
--- a/src/pages/admin/BannerManagePage.tsx
+++ b/src/pages/admin/BannerManagePage.tsx
@@ -1,18 +1,35 @@
 /**
  * 관리자 배너 관리 페이지
+ * 
+ * 기능:
+ * - 드래그 앤 드롭으로 순서 변경
+ * - 저장 버튼으로 변경사항 반영
+ * - 초기화 버튼으로 이전 상태 복원
+ * - 최대 10개 배너 제한
  */
 
-import { useState } from 'react';
-import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Eye, EyeOff, RotateCcw } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, Pencil, Trash2, Eye, EyeOff, RotateCcw, Save, GripVertical, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { Modal } from '@/components/common/Modal';
 import { Input } from '@/components/common/Input';
 import { useBannerStore } from '@/stores/useBannerStore';
 import type { Banner, BannerInput, BannerImageAlign, BannerImageFit } from '@/types/banner';
 
+const MAX_BANNERS = 10;
+
 const BannerManagePage = () => {
-  const { banners, addBanner, updateBanner, deleteBanner, toggleBannerActive, moveBannerUp, moveBannerDown, resetToDefault } = useBannerStore();
+  const { banners: storeBanners, setBanners, addBanner, updateBanner, deleteBanner } = useBannerStore();
   
+  // 로컬 상태 (저장 전까지 변경사항 보관)
+  const [localBanners, setLocalBanners] = useState<Banner[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  
+  // 드래그 앤 드롭 상태
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  
+  // 모달 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingBanner, setEditingBanner] = useState<Banner | null>(null);
   const [formData, setFormData] = useState<BannerInput>({
@@ -26,9 +43,86 @@ const BannerManagePage = () => {
     ctaLink: '',
   });
   
-  const sortedBanners = [...banners].sort((a, b) => a.order - b.order);
+  // Store 배너를 로컬 상태로 동기화
+  useEffect(() => {
+    const sorted = [...storeBanners].sort((a, b) => a.order - b.order);
+    setLocalBanners(sorted);
+    setHasChanges(false);
+  }, [storeBanners]);
   
+  // 정렬된 로컬 배너
+  const sortedBanners = [...localBanners].sort((a, b) => a.order - b.order);
+  
+  // 드래그 시작
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index);
+  };
+  
+  // 드래그 오버
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (draggedIndex !== null && draggedIndex !== index) {
+      setDragOverIndex(index);
+    }
+  };
+  
+  // 드롭
+  const handleDrop = useCallback((dropIndex: number) => {
+    if (draggedIndex === null || draggedIndex === dropIndex) {
+      setDraggedIndex(null);
+      setDragOverIndex(null);
+      return;
+    }
+    
+    const newBanners = [...sortedBanners];
+    const [draggedItem] = newBanners.splice(draggedIndex, 1);
+    newBanners.splice(dropIndex, 0, draggedItem);
+    
+    // order 재할당
+    const reorderedBanners = newBanners.map((banner, idx) => ({
+      ...banner,
+      order: idx + 1
+    }));
+    
+    setLocalBanners(reorderedBanners);
+    setHasChanges(true);
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  }, [draggedIndex, sortedBanners]);
+  
+  // 드래그 종료
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+    setDragOverIndex(null);
+  };
+  
+  // 활성/비활성 토글 (로컬)
+  const handleToggleActive = (id: string) => {
+    setLocalBanners(prev =>
+      prev.map(b => b.id === id ? { ...b, isActive: !b.isActive } : b)
+    );
+    setHasChanges(true);
+  };
+  
+  // 저장
+  const handleSave = () => {
+    setBanners(localBanners);
+    setHasChanges(false);
+  };
+  
+  // 초기화 (이전 상태로 복원)
+  const handleReset = () => {
+    const sorted = [...storeBanners].sort((a, b) => a.order - b.order);
+    setLocalBanners(sorted);
+    setHasChanges(false);
+  };
+  
+  // 배너 추가 모달 열기
   const handleOpenCreate = () => {
+    if (localBanners.length >= MAX_BANNERS) {
+      alert(`배너는 최대 ${MAX_BANNERS}개까지 등록할 수 있습니다.`);
+      return;
+    }
     setEditingBanner(null);
     setFormData({
       title: '',
@@ -43,6 +137,7 @@ const BannerManagePage = () => {
     setIsModalOpen(true);
   };
   
+  // 배너 수정 모달 열기
   const handleOpenEdit = (banner: Banner) => {
     setEditingBanner(banner);
     setFormData({
@@ -58,6 +153,7 @@ const BannerManagePage = () => {
     setIsModalOpen(true);
   };
   
+  // 배너 추가/수정 제출
   const handleSubmit = () => {
     if (editingBanner) {
       updateBanner(editingBanner.id, formData);
@@ -67,6 +163,7 @@ const BannerManagePage = () => {
     setIsModalOpen(false);
   };
   
+  // 배너 삭제
   const handleDelete = (id: string) => {
     if (confirm('정말로 이 배너를 삭제하시겠습니까?')) {
       deleteBanner(id);
@@ -81,32 +178,68 @@ const BannerManagePage = () => {
     { value: 'from-neutral-900 to-neutral-800', label: '어두운색' },
   ];
   
+  const isMaxReached = localBanners.length >= MAX_BANNERS;
+  
   return (
     <div>
       {/* 페이지 헤더 */}
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold text-neutral-900">배너 관리</h1>
-          <p className="text-neutral-500 mt-1">홈 화면 롤링 배너를 관리합니다</p>
+          <p className="text-neutral-500 mt-1">
+            홈 화면 롤링 배너를 관리합니다 ({localBanners.length} / {MAX_BANNERS})
+          </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={resetToDefault}>
+          <Button 
+            variant="outline" 
+            onClick={handleReset}
+            disabled={!hasChanges}
+          >
             <RotateCcw className="w-4 h-4 mr-2" />
             초기화
           </Button>
-          <Button onClick={handleOpenCreate}>
+          <Button 
+            onClick={handleSave}
+            disabled={!hasChanges}
+            className={hasChanges ? 'bg-primary-600 hover:bg-primary-700' : ''}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            저장
+          </Button>
+          <Button 
+            onClick={handleOpenCreate}
+            disabled={isMaxReached}
+            title={isMaxReached ? `배너는 최대 ${MAX_BANNERS}개까지 등록할 수 있습니다.` : ''}
+          >
             <Plus className="w-4 h-4 mr-2" />
             배너 추가
           </Button>
         </div>
       </div>
       
+      {/* 변경사항 알림 */}
+      {hasChanges && (
+        <div className="mb-4 flex items-center gap-2 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg text-amber-800">
+          <AlertCircle className="w-5 h-5" />
+          <span className="text-sm font-medium">변경사항이 있습니다. 저장 버튼을 눌러 반영하세요.</span>
+        </div>
+      )}
+      
+      {/* 최대 배너 경고 */}
+      {isMaxReached && (
+        <div className="mb-4 flex items-center gap-2 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          <AlertCircle className="w-5 h-5" />
+          <span className="text-sm font-medium">최대 {MAX_BANNERS}개의 배너가 등록되어 있습니다. 새 배너를 추가하려면 기존 배너를 삭제하세요.</span>
+        </div>
+      )}
+      
       {/* 배너 목록 */}
       <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
         <table className="w-full">
           <thead className="bg-neutral-50 border-b border-neutral-200">
             <tr>
-              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">순서</th>
+              <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600 w-20">순서</th>
               <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">이미지</th>
               <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">제목</th>
               <th className="px-4 py-3 text-left text-sm font-medium text-neutral-600">타입</th>
@@ -116,26 +249,21 @@ const BannerManagePage = () => {
           </thead>
           <tbody>
             {sortedBanners.map((banner, index) => (
-              <tr key={banner.id} className="border-b border-neutral-100 hover:bg-neutral-50">
+              <tr 
+                key={banner.id} 
+                draggable
+                onDragStart={() => handleDragStart(index)}
+                onDragOver={(e) => handleDragOver(e, index)}
+                onDrop={() => handleDrop(index)}
+                onDragEnd={handleDragEnd}
+                className={`border-b border-neutral-100 transition-all cursor-grab active:cursor-grabbing
+                  ${draggedIndex === index ? 'opacity-50 bg-primary-50' : 'hover:bg-neutral-50'}
+                  ${dragOverIndex === index ? 'border-t-2 border-t-primary-500' : ''}`}
+              >
                 <td className="px-4 py-3">
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm font-medium text-neutral-900">{banner.order}</span>
-                    <div className="flex flex-col ml-2">
-                      <button 
-                        onClick={() => moveBannerUp(banner.id)}
-                        disabled={index === 0}
-                        className="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-30"
-                      >
-                        <ChevronUp className="w-4 h-4" />
-                      </button>
-                      <button 
-                        onClick={() => moveBannerDown(banner.id)}
-                        disabled={index === sortedBanners.length - 1}
-                        className="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-30"
-                      >
-                        <ChevronDown className="w-4 h-4" />
-                      </button>
-                    </div>
+                  <div className="flex items-center gap-2">
+                    <GripVertical className="w-4 h-4 text-neutral-400" />
+                    <span className="text-sm font-medium text-neutral-900 w-6 text-center">{index + 1}</span>
                   </div>
                 </td>
                 <td className="px-4 py-3">
@@ -143,6 +271,7 @@ const BannerManagePage = () => {
                     src={banner.image} 
                     alt={banner.title}
                     className="w-20 h-12 object-cover rounded"
+                    draggable={false}
                   />
                 </td>
                 <td className="px-4 py-3">
@@ -167,7 +296,7 @@ const BannerManagePage = () => {
                 </td>
                 <td className="px-4 py-3">
                   <button 
-                    onClick={() => toggleBannerActive(banner.id)}
+                    onClick={() => handleToggleActive(banner.id)}
                     className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded ${
                       banner.isActive
                         ? 'bg-green-100 text-green-700'
@@ -190,7 +319,7 @@ const BannerManagePage = () => {
                 </td>
               </tr>
             ))}
-            {banners.length === 0 && (
+            {localBanners.length === 0 && (
               <tr>
                 <td colSpan={6} className="px-4 py-12 text-center text-neutral-500">
                   등록된 배너가 없습니다. 배너를 추가해주세요.

--- a/src/stores/useBannerStore.ts
+++ b/src/stores/useBannerStore.ts
@@ -21,6 +21,9 @@ interface BannerStore {
   updateBanner: (id: string, input: Partial<BannerInput>) => void;
   deleteBanner: (id: string) => void;
   
+  // 배너 목록 일괄 저장 (어드민용)
+  setBanners: (banners: Banner[]) => void;
+  
   // 활성화/비활성화
   toggleBannerActive: (id: string) => void;
   
@@ -74,6 +77,10 @@ export const useBannerStore = create<BannerStore>()(
       
       deleteBanner: (id) => {
         set({ banners: get().banners.filter(b => b.id !== id) });
+      },
+      
+      setBanners: (banners) => {
+        set({ banners });
       },
       
       toggleBannerActive: (id) => {


### PR DESCRIPTION
## 개요
배너 관리 페이지의 사용성을 개선합니다.

## 변경 사항
- 드래그 앤 드롭으로 순서 변경
- 저장/초기화 버튼 추가 (로컬 상태 관리)
- UI 순서 번호 표시 (1, 2, 3...)
- 최대 10개 배너 제한
- Store에 setBanners 함수 추가

## 테스트
- [x] 빌드 성공
- [x] 드래그 앤 드롭 동작
- [x] 저장 후 반영 확인
- [x] 초기화로 원복 확인
- [x] 10개 제한 표시