### PR TITLE
[개선] 대시보드 통계 집계 데이터 및 변화율 구현

### DIFF
--- a/src/mocks/stats.ts
+++ b/src/mocks/stats.ts
@@ -1,0 +1,170 @@
+/**
+ * 어드민 대시보드 통계 Mock 데이터
+ * 
+ * 집계 기준:
+ * - 매일 00:00 (자정) 기준으로 일일 집계
+ * - 월간 비교: 이번 달 vs 이전 달 (동일 기간 기준)
+ * - 변화율: (현재 기간 - 이전 기간) / 이전 기간 * 100
+ */
+
+/**
+ * 일일 통계 스냅샷
+ */
+export interface DailyStats {
+  date: string; // YYYY-MM-DD
+  aggregatedAt: string; // ISO datetime (집계 시점)
+  totalRevenue: number; // 해당 일자까지의 누적 거래액
+  confirmedOrdersCount: number; // 해당 일자까지의 구매확정 주문 수
+  totalUsers: number; // 해당 일자까지의 누적 회원 수
+  newUsersToday: number; // 해당 일자 신규 가입자 수
+  totalProducts: number; // 해당 일자 기준 등록 상품 수
+  totalOrders: number; // 해당 일자까지의 누적 주문 수
+  ordersToday: number; // 해당 일자 신규 주문 수
+}
+
+/**
+ * 월간 통계 요약
+ */
+export interface MonthlyStats {
+  yearMonth: string; // YYYY-MM
+  aggregatedAt: string; // ISO datetime (집계 시점)
+  totalRevenue: number; // 해당 월 총 거래액
+  newUsers: number; // 해당 월 신규 가입자 수
+  newProducts: number; // 해당 월 신규 등록 상품 수
+  totalOrders: number; // 해당 월 총 주문 수
+}
+
+/**
+ * 대시보드 통계 집계 정보
+ */
+export interface StatsAggregation {
+  lastAggregatedAt: string; // 마지막 집계 시점
+  aggregationCycle: string; // 집계 주기 설명
+  currentPeriod: string; // 현재 집계 기간
+  comparisonPeriod: string; // 비교 기간
+}
+
+// 현재 날짜 기준으로 Mock 데이터 생성
+const today = new Date();
+const todayStr = today.toISOString().split('T')[0];
+const lastMidnight = new Date(today);
+lastMidnight.setHours(0, 0, 0, 0);
+
+// 이번 달, 저번 달 계산
+const currentYear = today.getFullYear();
+const currentMonth = today.getMonth(); // 0-indexed
+const currentYearMonth = `${currentYear}-${String(currentMonth + 1).padStart(2, '0')}`;
+const prevMonth = currentMonth === 0 ? 11 : currentMonth - 1;
+const prevYear = currentMonth === 0 ? currentYear - 1 : currentYear;
+const prevYearMonth = `${prevYear}-${String(prevMonth + 1).padStart(2, '0')}`;
+
+/**
+ * 최근 7일간 일일 통계 (Mock)
+ */
+export const MOCK_DAILY_STATS: DailyStats[] = Array.from({ length: 7 }, (_, i) => {
+  const date = new Date(today);
+  date.setDate(date.getDate() - i);
+  const dateStr = date.toISOString().split('T')[0];
+  const midnight = new Date(date);
+  midnight.setHours(0, 0, 0, 0);
+  
+  // 일자별로 점진적으로 증가하는 데이터
+  const baseRevenue = 28500000;
+  const baseUsers = 20;
+  const baseProducts = 61;
+  const baseOrders = 69;
+  
+  return {
+    date: dateStr,
+    aggregatedAt: midnight.toISOString(),
+    totalRevenue: baseRevenue + (6 - i) * 850000,
+    confirmedOrdersCount: 32 + (6 - i) * 2,
+    totalUsers: baseUsers + (6 - i),
+    newUsersToday: i === 0 ? 0 : Math.floor(Math.random() * 3) + 1,
+    totalProducts: baseProducts + (6 - i),
+    totalOrders: baseOrders + (6 - i) * 2,
+    ordersToday: i === 0 ? 2 : Math.floor(Math.random() * 5) + 1,
+  };
+}).reverse();
+
+/**
+ * 최근 3개월 월간 통계 (Mock)
+ */
+export const MOCK_MONTHLY_STATS: MonthlyStats[] = [
+  // 이번 달 (진행 중)
+  {
+    yearMonth: currentYearMonth,
+    aggregatedAt: lastMidnight.toISOString(),
+    totalRevenue: 15280000,
+    newUsers: 14,
+    newProducts: 8,
+    totalOrders: 18,
+  },
+  // 지난 달
+  {
+    yearMonth: prevYearMonth,
+    aggregatedAt: new Date(prevYear, prevMonth + 1, 1, 0, 0, 0).toISOString(),
+    totalRevenue: 12450000,
+    newUsers: 11,
+    newProducts: 12,
+    totalOrders: 24,
+  },
+  // 2달 전
+  {
+    yearMonth: `${prevMonth === 0 ? prevYear - 1 : prevYear}-${String(prevMonth === 0 ? 12 : prevMonth).padStart(2, '0')}`,
+    aggregatedAt: new Date(prevMonth === 0 ? prevYear - 1 : prevYear, prevMonth === 0 ? 11 : prevMonth - 1, 1, 0, 0, 0).toISOString(),
+    totalRevenue: 10800000,
+    newUsers: 8,
+    newProducts: 15,
+    totalOrders: 21,
+  },
+];
+
+/**
+ * 집계 정보
+ */
+export const STATS_AGGREGATION_INFO: StatsAggregation = {
+  lastAggregatedAt: lastMidnight.toISOString(),
+  aggregationCycle: '매일 00:00 KST',
+  currentPeriod: `${currentYearMonth}-01 ~ ${todayStr}`,
+  comparisonPeriod: `${prevYearMonth}-01 ~ ${prevYearMonth}-${new Date(prevYear, prevMonth + 1, 0).getDate()}`,
+};
+
+/**
+ * 변화율 계산 헬퍼 함수
+ */
+export const calculateChangeRate = (current: number, previous: number): { value: number; isPositive: boolean } => {
+  if (previous === 0) {
+    return { value: current > 0 ? 100 : 0, isPositive: current > 0 };
+  }
+  const rate = ((current - previous) / previous) * 100;
+  return {
+    value: Math.abs(Math.round(rate * 10) / 10),
+    isPositive: rate >= 0,
+  };
+};
+
+/**
+ * 대시보드용 통계 데이터 (현재 vs 이전 달 비교)
+ */
+export const getDashboardStats = () => {
+  const current = MOCK_MONTHLY_STATS[0];
+  const previous = MOCK_MONTHLY_STATS[1];
+  
+  return {
+    // 현재 값
+    totalRevenue: current.totalRevenue,
+    newUsers: current.newUsers,
+    totalProducts: 61, // 전체 상품 수 (누적)
+    totalOrders: 69, // 전체 주문 수 (누적)
+    
+    // 변화율
+    revenueChange: calculateChangeRate(current.totalRevenue, previous.totalRevenue),
+    usersChange: calculateChangeRate(current.newUsers, previous.newUsers),
+    productsChange: calculateChangeRate(8, 12), // 이번 달 신규 vs 이전 달 신규
+    ordersChange: calculateChangeRate(current.totalOrders, previous.totalOrders),
+    
+    // 집계 정보
+    aggregation: STATS_AGGREGATION_INFO,
+  };
+};

--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -2,33 +2,21 @@
  * 관리자 대시보드 페이지
  * 
  * Mock 데이터에서 실제 통계를 계산하여 표시합니다.
+ * 
+ * 집계 기준:
+ * - 매일 00:00 KST 기준으로 집계
+ * - 변화율: 이번 달 vs 이전 달 동일 기간 비교
  */
 
 import { useMemo } from 'react';
-import { DollarSign, Users, Package, ShoppingCart } from 'lucide-react';
+import { DollarSign, Users, Package, ShoppingCart, Clock, Calendar, Info } from 'lucide-react';
 import StatsCard from '@/components/features/admin/StatsCard';
-import { MOCK_PRODUCTS } from '@/mocks/products';
-import { MOCK_USERS_DATA, MOCK_ORDER_HISTORY } from '@/mocks/users';
+import { MOCK_ORDER_HISTORY, MOCK_USERS_DATA } from '@/mocks/users';
+import { getDashboardStats, STATS_AGGREGATION_INFO } from '@/mocks/stats';
 
 const AdminDashboardPage = () => {
-  // Mock 데이터에서 실제 통계 계산
-  const stats = useMemo(() => {
-    // 총 거래액: 구매확정(CONFIRMED) 주문의 합계
-    const confirmedOrders = MOCK_ORDER_HISTORY.filter(o => o.status === 'CONFIRMED');
-    const totalRevenue = confirmedOrders.reduce((sum, o) => sum + o.totalPrice + o.shippingFee, 0);
-    
-    // 신규 가입자: 최근 30일 내 가입한 사용자
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const newUsers = MOCK_USERS_DATA.filter(u => new Date(u.createdAt) > thirtyDaysAgo).length;
-    
-    // 등록 상품: 전체 상품 수
-    const totalProducts = MOCK_PRODUCTS.length;
-    
-    // 총 주문: 전체 주문 수
-    const totalOrders = MOCK_ORDER_HISTORY.length;
-    
-    return { totalRevenue, newUsers, totalProducts, totalOrders };
-  }, []);
+  // Mock 데이터에서 통계 및 변화율 가져오기
+  const dashboardStats = useMemo(() => getDashboardStats(), []);
   
   // 최근 주문 5개 (최신순)
   const recentOrders = useMemo(() => {
@@ -59,48 +47,98 @@ const AdminDashboardPage = () => {
     return `${Math.floor(diffDays / 30)}개월 전`;
   };
   
+  // 집계 시점 포맷
+  const formatAggregationTime = (isoString: string) => {
+    const date = new Date(isoString);
+    return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')} 00:00`;
+  };
+  
   return (
     <div>
       {/* 페이지 헤더 */}
-      <div className="mb-8">
+      <div className="mb-6">
         <h1 className="text-2xl font-bold text-neutral-900">대시보드</h1>
         <p className="text-neutral-500 mt-1">플랫폼 운영 현황을 확인하세요</p>
+      </div>
+      
+      {/* 집계 정보 배너 */}
+      <div className="mb-6 p-4 bg-neutral-50 border border-neutral-200 rounded-lg">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+          <div className="flex items-center gap-2 text-neutral-600">
+            <Clock className="w-4 h-4" />
+            <span className="font-medium">마지막 집계:</span>
+            <span>{formatAggregationTime(STATS_AGGREGATION_INFO.lastAggregatedAt)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-neutral-600">
+            <Calendar className="w-4 h-4" />
+            <span className="font-medium">집계 주기:</span>
+            <span>{STATS_AGGREGATION_INFO.aggregationCycle}</span>
+          </div>
+          <div className="flex items-center gap-2 text-neutral-600">
+            <Info className="w-4 h-4" />
+            <span className="font-medium">현재 기간:</span>
+            <span>{STATS_AGGREGATION_INFO.currentPeriod}</span>
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-neutral-500">
+          * 변화율은 이번 달과 이전 달({STATS_AGGREGATION_INFO.comparisonPeriod}) 동일 기간을 비교한 값입니다.
+        </p>
       </div>
 
       {/* 통계 카드 그리드 */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <StatsCard
           icon={DollarSign}
-          label="총 거래액"
-          value={`${(stats.totalRevenue / 10000).toLocaleString()}만원`}
-          change={{ value: 12.5, isPositive: true }}
+          label="총 거래액 (이번 달)"
+          value={`${(dashboardStats.totalRevenue / 10000).toLocaleString()}만원`}
+          change={dashboardStats.revenueChange}
           iconColor="text-green-600"
           iconBgColor="bg-green-100"
         />
         <StatsCard
           icon={Users}
           label="신규 가입자 (이번 달)"
-          value={stats.newUsers.toLocaleString()}
-          change={{ value: 8.2, isPositive: true }}
+          value={dashboardStats.newUsers.toLocaleString()}
+          change={dashboardStats.usersChange}
           iconColor="text-blue-600"
           iconBgColor="bg-blue-100"
         />
         <StatsCard
           icon={Package}
-          label="등록 상품"
-          value={stats.totalProducts.toLocaleString()}
-          change={{ value: 3.1, isPositive: true }}
+          label="신규 상품 (이번 달)"
+          value="8"
+          change={dashboardStats.productsChange}
           iconColor="text-purple-600"
           iconBgColor="bg-purple-100"
         />
         <StatsCard
           icon={ShoppingCart}
-          label="총 주문"
-          value={stats.totalOrders.toLocaleString()}
-          change={{ value: 5.4, isPositive: true }}
+          label="신규 주문 (이번 달)"
+          value="18"
+          change={dashboardStats.ordersChange}
           iconColor="text-orange-600"
           iconBgColor="bg-orange-100"
         />
+      </div>
+      
+      {/* 누적 통계 */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <div className="bg-white rounded-lg border border-neutral-200 p-4 text-center">
+          <p className="text-2xl font-bold text-neutral-900">{dashboardStats.totalProducts}</p>
+          <p className="text-sm text-neutral-500">전체 등록 상품</p>
+        </div>
+        <div className="bg-white rounded-lg border border-neutral-200 p-4 text-center">
+          <p className="text-2xl font-bold text-neutral-900">{dashboardStats.totalOrders}</p>
+          <p className="text-sm text-neutral-500">전체 주문</p>
+        </div>
+        <div className="bg-white rounded-lg border border-neutral-200 p-4 text-center">
+          <p className="text-2xl font-bold text-neutral-900">20</p>
+          <p className="text-sm text-neutral-500">전체 회원</p>
+        </div>
+        <div className="bg-white rounded-lg border border-neutral-200 p-4 text-center">
+          <p className="text-2xl font-bold text-neutral-900">22</p>
+          <p className="text-sm text-neutral-500">전체 상점</p>
+        </div>
       </div>
 
       {/* 최근 활동 섹션 */}


### PR DESCRIPTION
## 개요
대시보드 통계의 변화율을 실제 데이터 기반으로 계산하고, 집계 기준 정보를 UI에 표시합니다.

## 변경 사항
- mocks/stats.ts: 일일/월간 통계, 집계 정보 Mock 데이터
- 집계 정보 배너: 마지막 집계 시점, 집계 주기(매일 00:00 KST), 현재/비교 기간
- 변화율: 이번 달 vs 이전 달 동일 기간 비교
- 누적 통계 섹션: 전체 상품, 주문, 회원, 상점 수

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 대시보드 집계 정보 배너 추가: 마지막 집계 시간, 집계 주기, 기간 정보 표시
  * 주요 지표 카드에 변화율 추가: 수익, 신규 사용자, 상품, 주문 전월 대비 비교
  * 누적 통계 섹션 신규 추가: 전체 등록 상품, 전체 주문, 전체 회원, 전체 상점 현황 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->