### PR TITLE
[수정] 대시보드 집계 기간 롤링 30일 기준 및 워딩 수정

### DIFF
--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -76,8 +76,8 @@ const AdminDashboardPage = () => {
           </div>
           <div className="flex items-center gap-2 text-neutral-600">
             <Info className="w-4 h-4" />
-            <span className="font-medium">현재 기간:</span>
-            <span>{STATS_AGGREGATION_INFO.currentPeriod}</span>
+            <span className="font-medium">집계 기간:</span>
+            <span>{STATS_AGGREGATION_INFO.aggregationPeriod}</span>
           </div>
         </div>
         <p className="mt-2 text-xs text-neutral-500">


### PR DESCRIPTION
## 개요
집계 기간을 롤링 30일 기준으로 변경하고, 워딩을 명확하게 수정합니다.

## 변경 사항
- 집계 기간: 최근 30일 (T-29 ~ 오늘)
- 비교 기간: 이전 30일 (T-59 ~ T-30)
- '현재 기간'  '집계 기간' 워딩 변경
- stats.ts 롤링 30일 기간 로직 전체 재작성