### PR TITLE
[수정] 배너 ctaEnabled 기본값 처리 추가

### DIFF
--- a/src/components/features/home/HeroBanner.tsx
+++ b/src/components/features/home/HeroBanner.tsx
@@ -147,7 +147,7 @@ export function HeroBanner() {
                     ${banner.imageAlign === 'full' ? 'text-neutral-200' : 'text-neutral-600'}`}>
                     {banner.description}
                   </p>
-                  {banner.ctaEnabled && banner.ctaLink && (
+                  {(banner.ctaEnabled ?? true) && banner.ctaLink && (
                     <div className="pt-2 min-[360px]:pt-3">
                       <Link to={banner.ctaLink}>
                         <Button 
@@ -186,7 +186,7 @@ export function HeroBanner() {
                     ${banner.imageAlign === 'full' ? 'text-neutral-200' : 'text-neutral-600'}`}>
                     {banner.description}
                   </p>
-                  {banner.ctaEnabled && banner.ctaLink && (
+                  {(banner.ctaEnabled ?? true) && banner.ctaLink && (
                     <div>
                       <Link to={banner.ctaLink}>
                         <Button 


### PR DESCRIPTION
## 개요
ctaEnabled 설정이 저장되어도 메인페이지에 반영되지 않는 버그를 수정합니다.

## 문제 원인
- 기존 배너에 ctaEnabled 필드가 없을 때 undefined로 처리되어 버튼 미표시

## 수정 내용
- HeroBanner에서 (banner.ctaEnabled ?? true)로 기본값 처리
- 기존 배너(ctaEnabled 필드 없음)에서도 버튼 정상 표시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 배너의 CTA 요소가 활성화 상태로 명시되지 않은 경우 기본적으로 표시되도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->