### PR TITLE
[수정] 배너 버튼 표시 조건 수정

### DIFF
--- a/src/components/features/home/HeroBanner.tsx
+++ b/src/components/features/home/HeroBanner.tsx
@@ -147,9 +147,9 @@ export function HeroBanner() {
                     ${banner.imageAlign === 'full' ? 'text-neutral-200' : 'text-neutral-600'}`}>
                     {banner.description}
                   </p>
-                  {(banner.ctaEnabled ?? true) && banner.ctaLink && (
+                  {(banner.ctaEnabled ?? true) && banner.ctaText && (
                     <div className="pt-2 min-[360px]:pt-3">
-                      <Link to={banner.ctaLink}>
+                      <Link to={banner.ctaLink || '#'}>
                         <Button 
                           size="sm"
                           className={`font-bold text-sm ${
@@ -186,9 +186,9 @@ export function HeroBanner() {
                     ${banner.imageAlign === 'full' ? 'text-neutral-200' : 'text-neutral-600'}`}>
                     {banner.description}
                   </p>
-                  {(banner.ctaEnabled ?? true) && banner.ctaLink && (
+                  {(banner.ctaEnabled ?? true) && banner.ctaText && (
                     <div>
-                      <Link to={banner.ctaLink}>
+                      <Link to={banner.ctaLink || '#'}>
                         <Button 
                           size="lg" 
                           className={`font-bold ${


### PR DESCRIPTION
## 개요
버튼 없는 배너 생성 후 활성화해도 저장 후 버튼이 안 보이는 버그를 수정합니다.

## 문제 원인
- 버튼 표시 조건이 ctaLink 인데, 빈 문자열이면 falsy라서 버튼 미표시

## 수정 내용
- ctaEnabled와 ctaText가 있으면 버튼 표시
- ctaLink 빈 문자열일 때 기본값 '#' 적용