### PR TITLE
[fix] 토스페이먼츠 멱등키 개선 및 URL 파라미터 중복 방지 (#125)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,10 @@ function App() {
                 <Route path="checkout" element={<CheckoutPage />} />
                 <Route path="payment/success" element={<PaymentSuccessPage />} />
                 <Route path="payment/fail" element={<PaymentFailPage />} />
+                
+                {/* 백엔드 리다이렉트 경로 호환성 (Aliasing) */}
+                <Route path="payments/toss/success" element={<PaymentSuccessPage />} />
+                <Route path="payments/toss/fail" element={<PaymentFailPage />} />
               </Route>
 
 

--- a/src/pages/SuccessPage.tsx
+++ b/src/pages/SuccessPage.tsx
@@ -34,7 +34,8 @@ export default function SuccessPage() {
 
       // 백엔드에 결제 승인 요청
       try {
-        const idempotencyKey = self.crypto.randomUUID();
+        // [FIX] paymentUuid를 멱등키로 사용하여 새로고침 시 중복 승인 방지
+        const idempotencyKey = paymentUuid;
         
         const response = await paymentService.confirmPayment({
           paymentUuid,


### PR DESCRIPTION
백엔드 수정 사항에 따른 결제 연동 보완 작업입니다.
- orderUuid/paymentUuid 기반 멱등키 고정 (새로고침 시 중복 처리 방지)
- successUrl 내 paymentUuid 중복 방지 로직 추가 (백엔드 파라미터 유무에 상관없이 안전하게 처리)
- 백엔드 리다이렉트 경로 호환성(Alias) 추가 (/payments/toss/success 등)

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 결제 중복 제출 방지 개선
  * 결제 리다이렉트 경로 호환성 강화
  * 결제 성공/실패 페이지 URL 파라미터 처리 안정화

* **새로운 기능**
  * 결제 결과 페이지 추가 접근 경로 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->