### PR TITLE
fix(ux): 이미지 렌더 안정화 및 Toast 훅 경로 정리

### DIFF
--- a/src/components/features/admin/AdminProductList.tsx
+++ b/src/components/features/admin/AdminProductList.tsx
@@ -109,6 +109,8 @@ const AdminProductList = () => {
                     <img
                       src={product.image}
                       alt={product.title}
+                      width={48}
+                      height={48}
                       className="w-12 h-12 rounded-lg object-cover"
                     />
                     <div>

--- a/src/components/features/admin/AdminUserList.tsx
+++ b/src/components/features/admin/AdminUserList.tsx
@@ -115,6 +115,8 @@ const AdminUserList = () => {
                     <img
                       src={user.avatar}
                       alt={user.nickname}
+                      width={40}
+                      height={40}
                       className="w-10 h-10 rounded-full object-cover"
                     />
                     <div>

--- a/src/components/features/mypage/OrderHistoryCard.tsx
+++ b/src/components/features/mypage/OrderHistoryCard.tsx
@@ -84,6 +84,8 @@ const OrderHistoryCard = ({ order }: OrderHistoryCardProps) => {
             <img
               src={image || '/images/placeholder.png'}
               alt={title}
+              width={80}
+              height={80}
               className="w-full h-full object-cover"
             />
           </Link>

--- a/src/components/features/mypage/ProfileCard.tsx
+++ b/src/components/features/mypage/ProfileCard.tsx
@@ -21,7 +21,7 @@ const ProfileCard = ({ user }: ProfileCardProps) => {
       <div className="flex items-start gap-4 mb-6">
         <div className="w-16 h-16 rounded-full overflow-hidden bg-neutral-200 flex-shrink-0">
           {user.avatar ? (
-            <img src={user.avatar} alt={user.nickname} className="w-full h-full object-cover" />
+            <img src={user.avatar} alt={user.nickname} width={64} height={64} className="w-full h-full object-cover" />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-xl font-bold text-neutral-400">
               {user.nickname.charAt(0)}

--- a/src/components/features/mypage/SalesProductCard.tsx
+++ b/src/components/features/mypage/SalesProductCard.tsx
@@ -35,6 +35,8 @@ const SalesProductCard = ({ product }: SalesProductCardProps) => {
         <img
           src={product.image}
           alt={product.title}
+          width={80}
+          height={80}
           className="w-full h-full object-cover"
         />
       </Link>
@@ -72,6 +74,7 @@ const SalesProductCard = ({ product }: SalesProductCardProps) => {
       <button
         className="p-2 text-neutral-400 hover:text-neutral-600 self-center"
         title="더보기"
+        aria-label="상품 더보기"
       >
         <MoreVertical className="w-5 h-5" />
       </button>

--- a/src/components/features/order/OrderItemList.tsx
+++ b/src/components/features/order/OrderItemList.tsx
@@ -27,6 +27,8 @@ const OrderItemList = ({ items }: OrderItemListProps) => {
               <img
                 src={item.thumbnailUrl || ''}
                 alt={item.title}
+                width={80}
+                height={80}
                 className="w-full h-full object-cover"
               />
             </div>

--- a/src/components/features/product/ProductImageGallery.tsx
+++ b/src/components/features/product/ProductImageGallery.tsx
@@ -22,6 +22,8 @@ export const ProductImageGallery = ({ images, mainImage, title }: ProductImageGa
         <img
           src={displayImages[activeImageIndex] || mainImage}
           alt={title}
+          width={800}
+          height={800}
           className="h-full w-full object-cover object-center"
         />
       </div>
@@ -35,7 +37,7 @@ export const ProductImageGallery = ({ images, mainImage, title }: ProductImageGa
                 activeImageIndex === idx ? 'border-primary-500' : 'border-transparent'
               }`}
             >
-              <img src={img} alt={`View ${idx + 1}`} className="h-full w-full object-cover" />
+              <img src={img} alt={`View ${idx + 1}`} width={64} height={64} className="h-full w-full object-cover" />
             </button>
           ))}
         </div>

--- a/src/components/features/product/SellerProfileCard.tsx
+++ b/src/components/features/product/SellerProfileCard.tsx
@@ -29,6 +29,8 @@ export const SellerProfileCard = ({ seller }: SellerProfileCardProps) => {
             <img 
               src={seller.avatar || `https://ui-avatars.com/api/?name=${seller.nickname}&background=random`} 
               alt={seller.nickname} 
+              width={48}
+              height={48}
               className="h-full w-full object-cover" 
             />
           </div>

--- a/src/components/features/review/ReviewCard.tsx
+++ b/src/components/features/review/ReviewCard.tsx
@@ -36,7 +36,13 @@ export function ReviewCard({ review }: ReviewCardProps) {
         {/* 프로필 이미지 */}
         <div className="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center overflow-hidden flex-shrink-0">
           {review.buyer.avatar ? (
-            <img src={review.buyer.avatar} alt="" className="w-full h-full object-cover" />
+            <img
+              src={review.buyer.avatar}
+              alt={review.buyer.nickname}
+              width={40}
+              height={40}
+              className="w-full h-full object-cover"
+            />
           ) : (
             <UserIcon className="w-5 h-5 text-neutral-400" />
           )}

--- a/src/components/features/review/ReviewForm.tsx
+++ b/src/components/features/review/ReviewForm.tsx
@@ -83,7 +83,7 @@ export const ReviewForm = ({ orderId, productTitle, onSubmit, onCancel }: Review
         <div className="flex gap-2">
           {images.map((img, idx) => (
             <div key={idx} className="relative w-20 h-20 border border-neutral-200 rounded-lg overflow-hidden">
-              <img src={img} alt={`review-${idx}`} className="w-full h-full object-cover" />
+              <img src={img} alt={`review-${idx}`} width={80} height={80} className="w-full h-full object-cover" />
               <button
                 type="button"
                 onClick={() => removeImage(idx)}

--- a/src/components/features/seller/MyShopInfo.tsx
+++ b/src/components/features/seller/MyShopInfo.tsx
@@ -85,6 +85,8 @@ const MyShopInfo = () => {
                 <img
                   src={editForm.avatar || 'https://ui-avatars.com/api/?name=Shop&background=random'}
                   alt="상점 아바타"
+                  width={80}
+                  height={80}
                   className="w-full h-full object-cover"
                 />
               </div>
@@ -93,6 +95,7 @@ const MyShopInfo = () => {
                 onClick={handleAvatarClick}
                 className="absolute -bottom-1 -right-1 w-8 h-8 rounded-full bg-primary-500 text-white
                   flex items-center justify-center shadow-lg hover:bg-primary-600 transition-colors"
+                aria-label="상점 프로필 이미지 변경"
               >
                 <Camera className="w-4 h-4" />
               </button>
@@ -139,6 +142,8 @@ const MyShopInfo = () => {
             <img
               src={shopInfo.avatar || 'https://ui-avatars.com/api/?name=Shop&background=random'}
               alt="상점 아바타"
+              width={80}
+              height={80}
               className="w-full h-full object-cover"
             />
           </div>

--- a/src/components/features/seller/ProductImageUploader.tsx
+++ b/src/components/features/seller/ProductImageUploader.tsx
@@ -99,6 +99,8 @@ const ProductImageUploader = ({
             <img
               src={image}
               alt={`상품 이미지 ${index + 1}`}
+              width={320}
+              height={320}
               className="w-full h-full object-cover"
             />
             

--- a/src/components/features/seller/SellerProductCard.tsx
+++ b/src/components/features/seller/SellerProductCard.tsx
@@ -52,7 +52,7 @@ const SellerProductCard = ({ product }: SellerProductCardProps) => {
   return (
     <div className="flex gap-3 p-3 bg-white rounded-xl border border-neutral-200 hover:shadow-md transition-shadow">
       <Link to={`/products/${product.id}`} className="flex-shrink-0 w-20 h-20 rounded-lg overflow-hidden bg-neutral-100">
-        <img src={product.image || '/images/placeholder.png'} alt={product.title} className="w-full h-full object-cover" />
+        <img src={product.image || '/images/placeholder.png'} alt={product.title} width={80} height={80} className="w-full h-full object-cover" />
       </Link>
 
       <div className="flex-1 min-w-0">

--- a/src/pages/LikedProductsPage.tsx
+++ b/src/pages/LikedProductsPage.tsx
@@ -113,6 +113,8 @@ const LikedProductsPage = () => {
                   <img
                     src={product.thumbnailUrl || '/images/placeholder.png'}
                     alt={product.title}
+                    width={96}
+                    height={96}
                     className="w-full h-full object-cover"
                   />
                 </Link>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -64,7 +64,7 @@ const ProfilePage = () => {
           <div className="relative">
             <div className="w-24 h-24 rounded-full overflow-hidden bg-neutral-200">
               {avatar ? (
-                <img src={avatar} alt="프로필" className="w-full h-full object-cover" />
+                <img src={avatar} alt="프로필" width={96} height={96} className="w-full h-full object-cover" />
               ) : (
                 <div className="w-full h-full flex items-center justify-center text-3xl font-bold text-neutral-400">
                   {nickname.charAt(0)}

--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -163,6 +163,8 @@ const AdminDashboardPage = () => {
                   <img 
                     src={order.product.image} 
                     alt={order.product.title}
+                    width={40}
+                    height={40}
                     className="w-10 h-10 rounded-lg object-cover"
                   />
                   <div>
@@ -191,6 +193,8 @@ const AdminDashboardPage = () => {
                     <img 
                       src={user.avatar} 
                       alt={user.nickname}
+                      width={40}
+                      height={40}
                       className="w-10 h-10 rounded-full object-cover"
                     />
                   ) : (
@@ -216,4 +220,3 @@ const AdminDashboardPage = () => {
 };
 
 export default AdminDashboardPage;
-


### PR DESCRIPTION
## 변경 내용
- 주요 이미지에 width/height 명시로 CLS 완화
- real-data 구조에 맞게 useToast import 경로 정리
- 프로필/리뷰/목록 카드의 이미지 렌더 안정성 보강

## 검증
- npm run lint
- npm run build

Closes #153
