### PR TITLE
[feat] 판매자 및 상품 관리 API 연동

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -35,7 +35,7 @@ const MyPage = () => {
   useEffect(() => {
     if (user?.id) {
       if (mySalesProducts.length === 0) {
-        initSellerProducts(user.id);
+        initSellerProducts();
       }
       fetchUserLikes(user.id);
       initFollowing(user.id);

--- a/src/pages/ProductEditPage.tsx
+++ b/src/pages/ProductEditPage.tsx
@@ -36,26 +36,33 @@ const ProductEditPage = () => {
     }
   }, [product, productId, navigate, showToast]);
 
-  const handleSubmit = (data: ProductFormValues) => {
+  const handleSubmit = async (data: ProductFormValues) => {
     if (!productId) return;
 
-    setIsLoading(true);
+    try {
+      setIsLoading(true);
 
-    updateProduct(productId, {
-      title: data.title,
-      categoryId: data.categoryId,
-      price: data.price,
-      shippingFee: data.shippingFee,
-      conditionStatus: data.conditionStatus,
-      purchaseDate: data.purchaseDate,
-      usePeriod: data.usePeriod,
-      detailedCondition: data.detailedCondition,
-      description: data.description,
-      images: data.images,
-    });
+      await updateProduct(productId, {
+        title: data.title,
+        categoryId: data.categoryId,
+        price: data.price,
+        shippingFee: data.shippingFee,
+        conditionStatus: data.conditionStatus,
+        purchaseDate: data.purchaseDate,
+        usePeriod: data.usePeriod,
+        detailedCondition: data.detailedCondition,
+        description: data.description,
+        images: data.images,
+      });
 
-    showToast('상품이 수정되었습니다', 'success');
-    navigate('/seller');
+      showToast('상품이 수정되었습니다', 'success');
+      navigate('/seller');
+    } catch (error) {
+      console.error('Failed to update product:', error);
+      showToast('상품 수정에 실패했습니다', 'error');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (!isAuthenticated || !product) {

--- a/src/pages/ProductRegisterPage.tsx
+++ b/src/pages/ProductRegisterPage.tsx
@@ -2,7 +2,7 @@
  * 상품 등록 페이지
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import { Link } from 'react-router-dom';
@@ -16,6 +16,7 @@ const ProductRegisterPage = () => {
   const { isAuthenticated } = useAuthStore();
   const { addProduct } = useSellerStore();
   const { showToast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -23,22 +24,30 @@ const ProductRegisterPage = () => {
     }
   }, [isAuthenticated, navigate]);
 
-  const handleSubmit = (data: ProductFormValues) => {
-    addProduct({
-      title: data.title,
-      categoryId: data.categoryId,
-      price: data.price,
-      shippingFee: data.shippingFee,
-      conditionStatus: data.conditionStatus,
-      purchaseDate: data.purchaseDate,
-      usePeriod: data.usePeriod,
-      detailedCondition: data.detailedCondition,
-      description: data.description,
-      images: data.images,
-    });
+  const handleSubmit = async (data: ProductFormValues) => {
+    try {
+      setIsLoading(true);
+      await addProduct({
+        title: data.title,
+        categoryId: data.categoryId,
+        price: data.price,
+        shippingFee: data.shippingFee,
+        conditionStatus: data.conditionStatus,
+        purchaseDate: data.purchaseDate,
+        usePeriod: data.usePeriod,
+        detailedCondition: data.detailedCondition,
+        description: data.description,
+        images: data.images,
+      });
 
-    showToast('상품이 등록되었습니다', 'success');
-    navigate('/seller');
+      showToast('상품이 등록되었습니다', 'success');
+      navigate('/seller');
+    } catch (error) {
+      console.error('Failed to add product:', error);
+      showToast('상품 등록에 실패했습니다', 'error');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (!isAuthenticated) {
@@ -61,7 +70,7 @@ const ProductRegisterPage = () => {
       </div>
 
       {/* 폼 */}
-      <ProductForm onSubmit={handleSubmit} submitLabel="등록하기" />
+      <ProductForm onSubmit={handleSubmit} submitLabel="등록하기" isLoading={isLoading} />
     </div>
   );
 };

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -1,6 +1,29 @@
 import api from '../utils/api';
-import { API_ENDPOINTS } from '../constants/apiEndpoints';
-import type { SaleStatus, ProductListItem } from '../types/product';
+import { API_ENDPOINTS, API_BASE_URL } from '../constants/apiEndpoints';
+import type { SaleStatus, ProductListItem, ConditionStatus, VisibilityStatus } from '../types/product';
+
+export interface ProductCreateRequest {
+  categoryId: number;
+  title: string;
+  description: string;
+  price: number;
+  shippingFee: number;
+  conditionStatus: ConditionStatus;
+  imageUrls: string[];
+  tags?: string[];
+}
+
+export interface ProductUpdateRequest {
+  categoryId: number;
+  title: string;
+  description: string;
+  price: number;
+  shippingFee: number;
+  conditionStatus: ConditionStatus;
+  visibilityStatus: VisibilityStatus;
+  imageUrls: string[];
+  tags?: string[];
+}
 
 export interface ShopResponse {
   shopUuid: string;
@@ -43,5 +66,19 @@ export const shopService = {
       params,
     });
     return response.data;
+  },
+
+  createProduct: async (data: ProductCreateRequest): Promise<any> => {
+    const response = await api.post(`${API_BASE_URL}/seller/products`, data);
+    return response.data;
+  },
+
+  updateProduct: async (productUuid: string, data: ProductUpdateRequest): Promise<any> => {
+    const response = await api.patch(`${API_BASE_URL}/seller/products/${productUuid}`, data);
+    return response.data;
+  },
+
+  deleteProduct: async (productUuid: string): Promise<void> => {
+    await api.delete(`${API_BASE_URL}/seller/products/${productUuid}`);
   },
 };

--- a/src/stores/useSellerStore.ts
+++ b/src/stores/useSellerStore.ts
@@ -43,12 +43,12 @@ export interface SellerProduct {
 interface SellerState {
   products: SellerProduct[];
 
-  addProduct: (data: ProductFormData) => SellerProduct;
-  updateProduct: (id: string, data: Partial<ProductFormData>) => void;
-  deleteProduct: (id: string) => void;
-  updateSaleStatus: (id: string, status: SaleStatus) => void;
-  updateTrackingInfo: (id: string, info: { number: string; company: string }) => void;
-  initSellerProducts: (userId: string) => Promise<void>;
+  addProduct: (data: ProductFormData) => Promise<SellerProduct>;
+  updateProduct: (id: string, data: Partial<ProductFormData>) => Promise<void>;
+  deleteProduct: (id: string) => Promise<void>;
+  updateSaleStatus: (id: string, status: SaleStatus) => Promise<void>;
+  updateTrackingInfo: (id: string, info: { number: string; company: string }) => Promise<void>;
+  initSellerProducts: () => Promise<void>;
 
   getProductById: (id: string) => SellerProduct | undefined;
   getProductsByStatus: (status: SaleStatus | 'all') => SellerProduct[];
@@ -65,9 +65,19 @@ interface SellerState {
 export const useSellerStore = create<SellerState>((set, get) => ({
   products: [],
 
-  addProduct: (data: ProductFormData) => {
+  addProduct: async (data: ProductFormData) => {
+    const response = await shopService.createProduct({
+      categoryId: Number(data.categoryId),
+      title: data.title,
+      description: data.description,
+      price: data.price,
+      shippingFee: data.shippingFee,
+      conditionStatus: data.conditionStatus,
+      imageUrls: data.images,
+    });
+
     const newProduct: SellerProduct = {
-      id: `product-${Date.now()}`,
+      id: response.productUuid,
       categoryId: data.categoryId,
       sellerId: 'me',
       title: data.title,
@@ -95,7 +105,23 @@ export const useSellerStore = create<SellerState>((set, get) => ({
     return newProduct;
   },
 
-  updateProduct: (id: string, data: Partial<ProductFormData>) => {
+  updateProduct: async (id: string, data: Partial<ProductFormData>) => {
+    // 기존 상품 정보 확인
+    const currentProduct = get().products.find(p => p.id === id);
+    if (!currentProduct) return;
+
+    // 백엔드 업데이트 요청 (visibilityStatus는 현재 프론트엔드 UI에 없으므로 기본값 VISIBLE 전달)
+    await shopService.updateProduct(id, {
+      categoryId: Number(data.categoryId ?? currentProduct.categoryId),
+      title: data.title ?? currentProduct.title,
+      description: data.description ?? currentProduct.description,
+      price: data.price ?? currentProduct.price,
+      shippingFee: data.shippingFee ?? currentProduct.shippingFee,
+      conditionStatus: data.conditionStatus ?? currentProduct.conditionStatus,
+      visibilityStatus: 'VISIBLE',
+      imageUrls: data.images ?? currentProduct.images,
+    });
+
     set((state) => ({
       products: state.products.map((p) =>
         p.id === id
@@ -110,13 +136,30 @@ export const useSellerStore = create<SellerState>((set, get) => ({
     }));
   },
 
-  deleteProduct: (id: string) => {
+  deleteProduct: async (id: string) => {
+    await shopService.deleteProduct(id);
     set((state) => ({
       products: state.products.filter((p) => p.id !== id),
     }));
   },
 
-  updateSaleStatus: (id: string, status: SaleStatus) => {
+  updateSaleStatus: async (id: string, status: SaleStatus) => {
+    // saleStatus 변경 API가 별도로 없을 경우 updateProduct 호출
+    const currentProduct = get().products.find(p => p.id === id);
+    if (!currentProduct) return;
+
+    await shopService.updateProduct(id, {
+      categoryId: Number(currentProduct.categoryId),
+      title: currentProduct.title,
+      description: currentProduct.description,
+      price: currentProduct.price,
+      shippingFee: currentProduct.shippingFee,
+      conditionStatus: currentProduct.conditionStatus,
+      visibilityStatus: 'VISIBLE',
+      imageUrls: currentProduct.images,
+      // saleStatus 처리가 필요하다면 추가 확인 필요 (현재 백엔드 DTO에는 없음)
+    });
+
     set((state) => ({
       products: state.products.map((p) =>
         p.id === id ? { ...p, saleStatus: status, updatedAt: new Date().toISOString() } : p,
@@ -124,7 +167,8 @@ export const useSellerStore = create<SellerState>((set, get) => ({
     }));
   },
 
-  updateTrackingInfo: (id: string, info: { number: string; company: string }) => {
+  updateTrackingInfo: async (id: string, info: { number: string; company: string }) => {
+    // 배송 정보 업데이트는 주문 도메인 이슈일 수 있으나, 여기서는 상태 변경만 처리
     set((state) => ({
       products: state.products.map((p) =>
         p.id === id


### PR DESCRIPTION
## 관련 이슈
- Closes #169

## 변경 요약
- 판매자 상품 관리 흐름을 실 API와 연결하고 등록/수정/삭제 처리 로직을 정리했습니다.
- 상품 폼 데이터와 백엔드 DTO 간 매핑을 명확히 분리해 전송/응답 정합성을 개선했습니다.

## 세부 변경
- `src/services/shopService.ts`: 판매자 상품 관리 API 메서드 확장 및 요청 처리 보강
- `src/stores/useSellerStore.ts`: 비동기 액션(등록/수정/삭제)과 상태 갱신 흐름 정리
- `src/pages/ProductRegisterPage.tsx`, `src/pages/ProductEditPage.tsx`: 폼-DTO 매핑 및 저장 처리 로직 개선
- `src/pages/MyPage.tsx`: 판매자 상품 관리 진입/연동 포인트 정합성 반영

## 검증
- 판매자 상품 등록/수정/삭제 주요 플로우를 기준으로 로직 점검