### PR TITLE
회원가입 페이지: 인증 메일 전 필수값 검증 및 가입 멱등키 적용

### DIFF
--- a/src/components/features/auth/SignupForm.tsx
+++ b/src/components/features/auth/SignupForm.tsx
@@ -87,9 +87,49 @@ export function SignupForm() {
   }, [email]);
 
   const handleSendVerificationEmail = async () => {
-    const isValidEmail = await trigger('email');
-    if (!isValidEmail) {
-      showToast('이메일 형식을 먼저 확인해 주세요.', 'error');
+    const values = getValues();
+    if (!values.email?.trim()) {
+      setFocus('email');
+      showToast('이메일을 입력해 주세요.', 'error');
+      return;
+    }
+    if (!values.nickname?.trim()) {
+      setFocus('nickname');
+      showToast('닉네임을 입력해 주세요.', 'error');
+      return;
+    }
+    if (!values.password) {
+      setFocus('password');
+      showToast('비밀번호를 입력해 주세요.', 'error');
+      return;
+    }
+    if (!values.confirmPassword) {
+      setFocus('confirmPassword');
+      showToast('비밀번호 확인을 입력해 주세요.', 'error');
+      return;
+    }
+    if (!values.termsAccepted) {
+      setFocus('termsAccepted');
+      showToast('이용약관에 동의해 주세요.', 'error');
+      return;
+    }
+    if (!values.privacyAccepted) {
+      setFocus('privacyAccepted');
+      showToast('개인정보 처리방침에 동의해 주세요.', 'error');
+      return;
+    }
+
+    const verificationRequiredFields: Array<keyof SignupSchema> = [
+      'email',
+      'nickname',
+      'password',
+      'confirmPassword',
+      'termsAccepted',
+      'privacyAccepted',
+    ];
+    const isReadyForVerification = await trigger(verificationRequiredFields, { shouldFocus: true });
+    if (!isReadyForVerification) {
+      showToast('입력값을 다시 확인해 주세요.', 'error');
       return;
     }
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -22,7 +22,16 @@ export const authService = {
    * 회원가입
    */
   register: async (request: UserRegisterRequest): Promise<User> => {
-    const response = await api.post<User>(API_ENDPOINTS.USERS.REGISTER, request);
+    const idempotencyKey = crypto.randomUUID();
+    const response = await api.post<User>(
+      API_ENDPOINTS.USERS.REGISTER,
+      request,
+      {
+        headers: {
+          'Idempotency-Key': idempotencyKey,
+        },
+      },
+    );
     return response.data;
   },
 


### PR DESCRIPTION
## 작업 내용
- 인증 메일 발송 버튼 클릭 시 필수 입력값(이메일/닉네임/비밀번호/약관 동의) 선검증
- 누락 항목별 안내 메시지 및 포커스 이동 처리
- 회원가입 API 호출 시 Idempotency-Key 헤더 자동 주입

## 이슈
- Closes #179