### PR TITLE
로그인 페이지: 자동 로그인 체크값에 따른 저장소 분리

### DIFF
--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -57,7 +57,7 @@ export function LoginForm() {
   const onSubmit = async (data: LoginSchema) => {
     setIsLoading(true);
     try {
-      await login({ email: data.email, password: data.password });
+      await login({ email: data.email, password: data.password }, Boolean(data.autoLogin));
 
       const { user } = useAuthStore.getState();
       if (user) {

--- a/src/pages/admin/AdminLoginPage.tsx
+++ b/src/pages/admin/AdminLoginPage.tsx
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * 관리자 로그인 페이지
  */
 
@@ -12,6 +12,7 @@ import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 const AdminLoginPage = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [autoLogin, setAutoLogin] = useState(false);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   
@@ -24,7 +25,7 @@ const AdminLoginPage = () => {
     setIsLoading(true);
 
     try {
-      await login({ email, password });
+      await login({ email, password }, autoLogin);
       const { isAdminAuthenticated } = useAuthStore.getState();
 
       if (!isAdminAuthenticated) {
@@ -35,7 +36,7 @@ const AdminLoginPage = () => {
 
       navigate('/admin');
     } catch (loginError) {
-      console.error('Admin login failed:', loginError);
+      console.error('관리자 로그인 실패:', loginError);
       setError('로그인 정보가 올바르지 않습니다.');
     } finally {
       setIsLoading(false);
@@ -76,6 +77,15 @@ const AdminLoginPage = () => {
               autoComplete="current-password"
               className="bg-neutral-700 border-neutral-600 text-white placeholder:text-neutral-400"
             />
+            <label className="flex items-center gap-2 text-sm text-neutral-300">
+              <input
+                type="checkbox"
+                checked={autoLogin}
+                onChange={(e) => setAutoLogin(e.target.checked)}
+                className="h-4 w-4 rounded border-neutral-500 bg-neutral-700 text-primary-500 focus:ring-primary-500"
+              />
+              자동 로그인
+            </label>
           </div>
 
           {error && (
@@ -105,3 +115,4 @@ const AdminLoginPage = () => {
 };
 
 export default AdminLoginPage;
+

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -3,14 +3,41 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { authService } from "../services/authService";
 import type { LoginRequest, User, UserRegisterRequest } from "../types/auth";
 
+const authStorage = {
+  getItem: (name: string) => {
+    return localStorage.getItem(name) ?? sessionStorage.getItem(name);
+  },
+  setItem: (name: string, value: string) => {
+    try {
+      const parsed = JSON.parse(value) as { state?: { rememberMe?: boolean } };
+      const rememberMe = Boolean(parsed?.state?.rememberMe);
+      if (rememberMe) {
+        localStorage.setItem(name, value);
+        sessionStorage.removeItem(name);
+        return;
+      }
+    } catch {
+      // ignore parse errors and fallback to session storage
+    }
+
+    sessionStorage.setItem(name, value);
+    localStorage.removeItem(name);
+  },
+  removeItem: (name: string) => {
+    localStorage.removeItem(name);
+    sessionStorage.removeItem(name);
+  },
+};
+
 interface AuthState {
   user: User | null;
   accessToken: string | null;
   isAuthenticated: boolean;
   isAdminAuthenticated: boolean;
   isInitialized: boolean;
+  rememberMe: boolean;
 
-  login: (request: LoginRequest) => Promise<void>;
+  login: (request: LoginRequest, rememberMe?: boolean) => Promise<void>;
   register: (request: UserRegisterRequest) => Promise<void>;
   logout: () => void;
   initialize: () => Promise<void>;
@@ -26,11 +53,12 @@ export const useAuthStore = create<AuthState>()(
       isAuthenticated: false,
       isAdminAuthenticated: false,
       isInitialized: false,
+      rememberMe: false,
 
-      login: async (request: LoginRequest) => {
+      login: async (request: LoginRequest, rememberMe = true) => {
         try {
           const { accessToken } = await authService.login(request);
-          set({ accessToken, isAuthenticated: true });
+          set({ accessToken, isAuthenticated: true, rememberMe });
 
           const user = await authService.getMe();
           set({
@@ -43,6 +71,7 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
             isAdminAuthenticated: false,
             user: null,
+            rememberMe: false,
           });
           throw error;
         }
@@ -58,6 +87,7 @@ export const useAuthStore = create<AuthState>()(
           accessToken: null,
           isAuthenticated: false,
           isAdminAuthenticated: false,
+          rememberMe: false,
         });
       },
 
@@ -86,6 +116,7 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
             isAdminAuthenticated: false,
             isInitialized: true,
+            rememberMe: false,
           });
         }
       },
@@ -98,13 +129,13 @@ export const useAuthStore = create<AuthState>()(
             isAdminAuthenticated: user.role === "ADMIN",
           });
         } catch (error) {
-          console.error("Refresh user failed:", error);
+          console.error("사용자 정보 새로고침 실패:", error);
         }
       },
 
       socialLogin: async (accessToken: string, _refreshToken?: string | null) => {
         try {
-          set({ accessToken, isAuthenticated: true });
+          set({ accessToken, isAuthenticated: true, rememberMe: true });
           const user = await authService.getMe();
           set({
             user: { ...user, id: user.userUuid },
@@ -116,6 +147,7 @@ export const useAuthStore = create<AuthState>()(
             isAuthenticated: false,
             isAdminAuthenticated: false,
             user: null,
+            rememberMe: false,
           });
           throw error;
         }
@@ -123,11 +155,12 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: "auth-storage",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => authStorage),
       partialize: (state) => ({
         accessToken: state.accessToken,
         isAuthenticated: state.isAuthenticated,
         user: state.user,
+        rememberMe: state.rememberMe,
       }),
     },
   ),


### PR DESCRIPTION
## 작업 내용
- 로그인/관리자 로그인에서 자동 로그인 체크값 전달
- auth-store에 rememberMe 상태 추가
- rememberMe 값에 따라 localStorage/sessionStorage 분기 저장

## 이슈
- Closes #180