### PR TITLE
이메일 인증 결과 페이지: resultToken 검증 기반 진입 제어

### DIFF
--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -14,6 +14,7 @@ export const API_ENDPOINTS = {
     PASSWORD: `${API_BASE_URL}/users/password`,
     ADDRESSES: `${API_BASE_URL}/users/me/addresses`,
     EMAIL_SEND: `${API_BASE_URL}/users/email/send`,
+    EMAIL_VERIFY_RESULT: `${API_BASE_URL}/users/email/verify/result`,
   },
   PAYMENTS: {
     PREPARE: `${API_BASE_URL}/payments/request`,

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -1,20 +1,74 @@
+import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
+import { authService } from '@/services/authService';
+
+type VerificationState = 'loading' | 'success' | 'failure';
 
 export default function EmailVerificationPage() {
   const [searchParams] = useSearchParams();
+  const [state, setState] = useState<VerificationState>('loading');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('인증 결과를 확인하는 중입니다.');
 
-  const verified = searchParams.get('verified') === 'true';
-  const email = searchParams.get('email') || '';
-  const message =
-    searchParams.get('message') ||
-    (verified ? '이메일 인증이 완료되었습니다.' : '이메일 인증에 실패했습니다.');
+  useEffect(() => {
+    const resultToken = searchParams.get('resultToken');
+    if (!resultToken) {
+      setState('failure');
+      setMessage('올바른 인증 경로로 접근해 주세요.');
+      return;
+    }
+
+    let isMounted = true;
+
+    authService
+      .verifyEmailResult(resultToken)
+      .then((result) => {
+        if (!isMounted) {
+          return;
+        }
+
+        if (result.verified) {
+          setState('success');
+          setEmail(result.email ?? '');
+          setMessage('이메일 인증이 완료되었습니다.');
+          return;
+        }
+
+        setState('failure');
+        setMessage('이메일 인증에 실패했습니다. 다시 시도해 주세요.');
+      })
+      .catch(() => {
+        if (!isMounted) {
+          return;
+        }
+        setState('failure');
+        setMessage('인증 결과 확인에 실패했습니다. 다시 시도해 주세요.');
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [searchParams]);
+
+  if (state === 'loading') {
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-3 py-8 min-[360px]:px-4 min-[360px]:py-12">
+        <Card className="w-full max-w-lg p-5 min-[360px]:p-8">
+          <div className="text-center space-y-5">
+            <h1 className="text-xl font-bold text-neutral-900 min-[360px]:text-2xl">이메일 인증 확인</h1>
+            <p className="text-neutral-600">{message}</p>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-3 py-8 min-[360px]:px-4 min-[360px]:py-12">
       <Card className="w-full max-w-lg p-5 min-[360px]:p-8">
-        {verified ? (
+        {state === 'success' ? (
           <div className="text-center space-y-5">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-600 text-2xl">
               ✓
@@ -24,7 +78,7 @@ export default function EmailVerificationPage() {
             {email && <p className="text-sm text-neutral-500 break-all">{email}</p>}
             <Link to="/login" className="block">
               <Button className="w-full" size="lg">
-                로그인 하러 가기
+                로그인하러 가기
               </Button>
             </Link>
           </div>

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -5,7 +5,8 @@ import type {
   User, 
   UserRegisterRequest, 
   UserUpdateRequest,
-  PasswordUpdateRequest
+  PasswordUpdateRequest,
+  EmailVerificationResult,
 } from '../types/auth';
 import { API_ENDPOINTS } from '../constants/apiEndpoints';
 
@@ -37,6 +38,14 @@ export const authService = {
 
   sendVerificationEmail: async (email: string): Promise<void> => {
     await api.post(API_ENDPOINTS.USERS.EMAIL_SEND, { email });
+  },
+
+  verifyEmailResult: async (resultToken: string): Promise<EmailVerificationResult> => {
+    const response = await api.post<EmailVerificationResult>(
+      API_ENDPOINTS.USERS.EMAIL_VERIFY_RESULT,
+      { resultToken },
+    );
+    return response.data;
   },
 
   /**

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -35,3 +35,8 @@ export interface PasswordUpdateRequest {
   currentPassword: string;
   newPassword: string;
 }
+
+export interface EmailVerificationResult {
+  verified: boolean;
+  email: string;
+}


### PR DESCRIPTION
## 작업 내용
- 이메일 인증 결과 페이지에서 resultToken 필수화
- resultToken 검증 API 호출 후 성공/실패 렌더링
- 결과 검증 API 엔드포인트/타입/서비스 메서드 추가

## 이슈
- Closes #181