### PR TITLE
fix(mypage): 판매 상품 카드 액션 및 목록 갱신 정리

### DIFF
--- a/src/components/features/mypage/SalesProductCard.tsx
+++ b/src/components/features/mypage/SalesProductCard.tsx
@@ -1,11 +1,10 @@
-/**
- * 판매 상품 카드 컴포넌트 (마이페이지용)
+﻿/**
+ * 판매 상품 카드 컴포넌트 (마이페이지)
  */
 
 import { Link } from 'react-router-dom';
 import Eye from 'lucide-react/dist/esm/icons/eye';
 import Heart from 'lucide-react/dist/esm/icons/heart';
-import MoreVertical from 'lucide-react/dist/esm/icons/more-vertical';
 import type { SaleStatus } from '@/types/product';
 import { formatTimeAgo } from '@/utils/date';
 import { formatPrice } from '@/utils/formatPrice';
@@ -27,7 +26,6 @@ interface SalesProductCardProps {
 const SalesProductCard = ({ product }: SalesProductCardProps) => {
   return (
     <div className="flex gap-4 p-3 rounded-xl hover:bg-neutral-50 transition-colors">
-      {/* 상품 이미지 */}
       <Link
         to={`/products/${product.id}`}
         className="w-20 h-20 rounded-lg overflow-hidden bg-neutral-100 flex-shrink-0"
@@ -41,7 +39,6 @@ const SalesProductCard = ({ product }: SalesProductCardProps) => {
         />
       </Link>
 
-      {/* 상품 정보 */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${SALE_STATUS_COLORS[product.saleStatus as SaleStatus] || SALE_STATUS_COLORS.ON_SALE}`}>
@@ -54,9 +51,7 @@ const SalesProductCard = ({ product }: SalesProductCardProps) => {
         >
           {product.title}
         </Link>
-        <p className="text-base font-bold text-neutral-900 mt-1">
-          {formatPrice(product.price)}
-        </p>
+        <p className="text-base font-bold text-neutral-900 mt-1">{formatPrice(product.price)}</p>
         <div className="flex items-center gap-3 mt-1 text-xs text-neutral-500">
           <span className="flex items-center gap-1">
             <Eye className="w-3.5 h-3.5" />
@@ -70,14 +65,12 @@ const SalesProductCard = ({ product }: SalesProductCardProps) => {
         </div>
       </div>
 
-      {/* 더보기 버튼 */}
-      <button
-        className="p-2 text-neutral-400 hover:text-neutral-600 self-center"
-        title="더보기"
-        aria-label="상품 더보기"
+      <Link
+        to={`/seller/products/${product.id}/edit`}
+        className="self-center px-2 py-1 text-xs font-medium text-neutral-600 border border-neutral-200 rounded-md hover:bg-neutral-100"
       >
-        <MoreVertical className="w-5 h-5" />
-      </button>
+        수정
+      </Link>
     </div>
   );
 };

--- a/src/components/features/seller/SellerProductCard.tsx
+++ b/src/components/features/seller/SellerProductCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+﻿import { Link } from 'react-router-dom';
 import Eye from 'lucide-react/dist/esm/icons/eye';
 import Heart from 'lucide-react/dist/esm/icons/heart';
 import MessageCircle from 'lucide-react/dist/esm/icons/message-circle';
@@ -42,7 +42,7 @@ const SellerProductCard = ({ product }: SellerProductCardProps) => {
   const handleDelete = () => {
     if (confirm('정말 삭제하시겠습니까?')) {
       deleteProduct(product.id);
-      showToast('상품을 삭제했습니다', 'error');
+      showToast('상품이 삭제되었습니다', 'error');
     }
     setShowMenu(false);
   };
@@ -61,34 +61,42 @@ const SellerProductCard = ({ product }: SellerProductCardProps) => {
             <h4 className="font-medium text-neutral-900 truncate hover:text-primary-600">{product.title}</h4>
           </Link>
 
-          <div className="relative">
-            <button onClick={() => setShowMenu((v) => !v)} className="p-1 rounded-lg hover:bg-neutral-100 text-neutral-500">
-              <MoreVertical className="w-4 h-4" />
-            </button>
+          <div className="flex items-center gap-1">
+            <Link
+              to={`/seller/products/${product.id}/edit`}
+              className="px-2 py-1 text-xs font-medium text-neutral-600 border border-neutral-200 rounded-md hover:bg-neutral-100"
+            >
+              수정
+            </Link>
+            <div className="relative">
+              <button onClick={() => setShowMenu((v) => !v)} className="p-1 rounded-lg hover:bg-neutral-100 text-neutral-500">
+                <MoreVertical className="w-4 h-4" />
+              </button>
 
-            {showMenu && (
-              <div className="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-lg border border-neutral-200 py-1 z-10">
-                {product.saleStatus !== 'ON_SALE' && (
-                  <button onClick={() => handleStatusChange('ON_SALE')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
-                    판매중으로 변경
+              {showMenu && (
+                <div className="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-lg border border-neutral-200 py-1 z-10">
+                  {product.saleStatus !== 'ON_SALE' && (
+                    <button onClick={() => handleStatusChange('ON_SALE')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
+                      판매중으로 변경
+                    </button>
+                  )}
+                  {product.saleStatus !== 'RESERVED' && (
+                    <button onClick={() => handleStatusChange('RESERVED')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
+                      예약중으로 변경
+                    </button>
+                  )}
+                  {product.saleStatus !== 'SOLD_OUT' && (
+                    <button onClick={() => handleStatusChange('SOLD_OUT')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
+                      판매완료로 변경
+                    </button>
+                  )}
+                  <hr className="my-1" />
+                  <button onClick={handleDelete} className="w-full text-left px-3 py-2 text-sm text-error-600 hover:bg-neutral-100">
+                    삭제
                   </button>
-                )}
-                {product.saleStatus !== 'RESERVED' && (
-                  <button onClick={() => handleStatusChange('RESERVED')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
-                    예약중으로 변경
-                  </button>
-                )}
-                {product.saleStatus !== 'SOLD_OUT' && (
-                  <button onClick={() => handleStatusChange('SOLD_OUT')} className="w-full text-left px-3 py-2 text-sm hover:bg-neutral-100">
-                    판매완료로 변경
-                  </button>
-                )}
-                <hr className="my-1" />
-                <button onClick={handleDelete} className="w-full text-left px-3 py-2 text-sm text-error-600 hover:bg-neutral-100">
-                  삭제
-                </button>
-              </div>
-            )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -34,9 +34,7 @@ const MyPage = () => {
 
   useEffect(() => {
     if (user?.id) {
-      if (mySalesProducts.length === 0) {
-        initSellerProducts();
-      }
+      initSellerProducts();
       fetchUserLikes(user.id);
       initFollowing(user.id);
       fetchBalance();
@@ -46,7 +44,7 @@ const MyPage = () => {
         setPurchaseCount(res.totalElements);
       }).catch(console.error);
     }
-  }, [user?.id, initSellerProducts, fetchUserLikes, initFollowing, mySalesProducts.length, fetchBalance]);
+  }, [user?.id, initSellerProducts, fetchUserLikes, initFollowing, fetchBalance]);
 
   // 로그인하지 않은 경우 로그인 페이지로 리다이렉트
   if (!isAuthenticated || !user) {


### PR DESCRIPTION
## 작업 내용
- 마이페이지 진입 시 판매상품 초기화 조건 제거
- 판매 상품 카드 더보기 액션을 수정 링크로 단순화
- 판매자 카드 수정 버튼 전면 배치 및 삭제 토스트 문구 정리

## 연관 이슈
- closes #189