### PR TITLE
feat: 주소 데이터 스키마 통일 (zonecode)

### DIFF
--- a/src/mocks/address.ts
+++ b/src/mocks/address.ts
@@ -9,7 +9,7 @@ export interface Address {
   phone: string;
   address: string;
   detailAddress: string;
-  zipCode: string;
+  zonecode: string;
   isDefault: boolean;
 }
 
@@ -21,7 +21,7 @@ export const MOCK_ADDRESSES: Address[] = [
     phone: '010-1234-5678',
     address: '서울시 강남구 테헤란로 123',
     detailAddress: '삼성동 아파트 101동 101호',
-    zipCode: '06234',
+    zonecode: '06234',
     isDefault: true,
   },
   {
@@ -31,7 +31,7 @@ export const MOCK_ADDRESSES: Address[] = [
     phone: '010-1234-5678',
     address: '서울시 강남구 역삼로 456',
     detailAddress: '메가타워 15층',
-    zipCode: '06245',
+    zonecode: '06245',
     isDefault: false,
   },
 ];

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,7 @@
 import api from "../utils/api";
 import { API_ENDPOINTS } from "../constants/apiEndpoints";
 import type { SaleStatus } from "../types/product";
+import type { PageResponse } from "../types/order";
 import type {
   User,
   UserUpdateRequest,
@@ -45,20 +46,22 @@ export interface DepositHistoryResponse {
 
 export interface Address {
   id: number;
-  receiverName: string;
-  receiverPhone: string;
-  zipcode: string;
-  address1: string;
-  address2: string;
+  name: string;
+  recipient: string;
+  phone: string;
+  zonecode: string;
+  address: string;
+  detailAddress: string;
   isDefault: boolean;
 }
 
 export interface AddressRequest {
-  receiverName: string;
-  receiverPhone: string;
-  zipcode: string;
-  address1: string;
-  address2: string;
+  name: string;
+  recipient: string;
+  phone: string;
+  zonecode: string;
+  address: string;
+  detailAddress: string;
   isDefault: boolean;
 }
 
@@ -96,8 +99,10 @@ export const userService = {
   },
 
   // Address
-  getMyAddresses: async (): Promise<Address[]> => {
-    const response = await api.get<Address[]>(API_ENDPOINTS.USERS.ADDRESSES);
+  getMyAddresses: async (page = 0, size = 10): Promise<PageResponse<Address> | Address[]> => {
+    const response = await api.get<PageResponse<Address> | Address[]>(API_ENDPOINTS.USERS.ADDRESSES, {
+      params: { page, size }
+    });
     return response.data;
   },
 

--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -1,11 +1,11 @@
 export interface Address {
-  id: string;
-  name: string;
+  id: number;
+  name?: string;
   recipient: string;
   phone: string;
   address: string;
   detailAddress: string;
-  zipCode: string;
+  zonecode: string;
   isDefault: boolean;
 }
 


### PR DESCRIPTION
## 작업 내용\n- Address 타입 우편번호 필드를 zonecode로 통일\n- 목업 주소 데이터 필드명 정리\n- userService 주소 타입/목록 조회를 페이지네이션 응답까지 대응\n\n## 관련 이슈\n- Closes #196