### PR TITLE
feat: 주문서 배송지 주소록 선택/저장 연동

### DIFF
--- a/src/components/features/address/AddressSelectionModal.tsx
+++ b/src/components/features/address/AddressSelectionModal.tsx
@@ -1,0 +1,26 @@
+import { Modal } from '../../common/Modal';
+import { AddressList } from './AddressList';
+import type { Address } from '../../../types/address';
+
+interface AddressSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (address: Address) => void;
+}
+
+export const AddressSelectionModal = ({
+  isOpen,
+  onClose,
+  onSelect
+}: AddressSelectionModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="배송지 선택" size="lg">
+      <div className="py-2">
+        <AddressList selectable onSelect={(address) => {
+          onSelect(address);
+          onClose();
+        }} />
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/features/order/AddressSelector.tsx
+++ b/src/components/features/order/AddressSelector.tsx
@@ -17,16 +17,26 @@ const AddressSelector = ({ selectedAddress, onSelect }: AddressSelectorProps) =>
   useEffect(() => {
     const loadAddresses = async () => {
       try {
-        const list = await userService.getMyAddresses();
-        const mapped = list.map((addr) => ({
-          id: String(addr.id),
-          name: addr.isDefault ? '기본 배송지' : '배송지',
-          recipient: addr.receiverName,
-          phone: addr.receiverPhone,
-          address: addr.address1,
-          detailAddress: addr.address2,
-          zipCode: addr.zipcode,
-          isDefault: addr.isDefault,
+        const response = await userService.getMyAddresses(0, 50); // Fetch enough for selector
+        console.log('[DEBUG] AddressSelector getMyAddresses response:', response);
+
+        // 데이터 추출 로직 개선: PageResponse 구조 또는 배열 구조 대응
+        let rawItems: any[] = [];
+        if (Array.isArray(response)) {
+          rawItems = response;
+        } else if (response && Array.isArray(response.content)) {
+          rawItems = response.content;
+        }
+
+        const mapped: Address[] = rawItems.map((item: any) => ({
+          id: item.id,
+          name: item.name || (item.isDefault || item.default ? '기본 배송지' : '배송지'),
+          recipient: item.recipient || '',
+          phone: item.phone || '',
+          address: item.address || '',
+          detailAddress: item.detailAddress || '',
+          zonecode: item.zonecode || '',
+          isDefault: Boolean(item.isDefault || item.default),
         }));
 
         setAddresses(mapped);
@@ -103,7 +113,7 @@ const AddressSelector = ({ selectedAddress, onSelect }: AddressSelectorProps) =>
                       {address.recipient} ({address.phone})
                     </p>
                     <p className="text-sm text-neutral-600">
-                      [{address.zipCode}] {address.address} {address.detailAddress}
+                      [{address.zonecode}] {address.address} {address.detailAddress}
                     </p>
                   </div>
                 </div>

--- a/src/components/features/order/ShippingInfoForm.tsx
+++ b/src/components/features/order/ShippingInfoForm.tsx
@@ -25,27 +25,43 @@ declare global {
 interface ShippingInfoFormProps {
   shippingInfo: Address | null;
   onUpdate: (info: Address) => void;
+  onSelectAddressbook?: () => void;
+  saveAddress?: boolean;
+  onSaveAddressChange?: (save: boolean) => void;
 }
 
 const KAKAO_POSTCODE_URL = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
 
-const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => {
-  // 배송지 폼 상태입니다.
+const ShippingInfoForm = ({ 
+  shippingInfo, 
+  onUpdate, 
+  onSelectAddressbook,
+  saveAddress,
+  onSaveAddressChange
+}: ShippingInfoFormProps) => {
+  // 배송지 폼 상태입니다. (id가 number인 경우를 위해 string | number 허용)
   const [formData, setFormData] = useState<Address>(
     shippingInfo || {
-      id: 'manual',
+      id: 'manual' as any,
       name: '기본 배송지',
       recipient: '',
       phone: '',
-      zipCode: '',
       address: '',
       detailAddress: '',
+      zonecode: '',
       isDefault: false,
     }
   );
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMessage, setModalMessage] = useState('');
+
+  // 외부 props인 shippingInfo가 변경되면 내부 상태(formData)도 동기화합니다.
+  useEffect(() => {
+    if (shippingInfo) {
+      setFormData(shippingInfo);
+    }
+  }, [shippingInfo]);
 
   // 카카오 우편번호 스크립트를 로드합니다.
   useEffect(() => {
@@ -78,7 +94,7 @@ const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => 
         const updatedData = {
           ...formData,
           address: data.address,
-          zipCode: data.zonecode,
+          zonecode: data.zonecode,
         };
 
         setFormData(updatedData);
@@ -90,8 +106,17 @@ const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => 
   return (
     <>
       <div className="bg-white rounded-2xl border border-neutral-200 overflow-hidden">
-        <div className="px-5 py-4 border-b border-neutral-200 bg-neutral-50">
+        <div className="px-5 py-4 border-b border-neutral-200 bg-neutral-50 flex justify-between items-center">
           <h3 className="font-bold text-neutral-900">배송지 정보</h3>
+          {onSelectAddressbook && (
+            <button
+              type="button"
+              onClick={onSelectAddressbook}
+              className="text-xs font-bold text-primary-600 hover:text-primary-700 transition-colors"
+            >
+              주소록에서 선택
+            </button>
+          )}
         </div>
 
         <div className="p-5 space-y-4">
@@ -127,9 +152,8 @@ const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => 
             <div className="flex gap-2">
               <input
                 type="text"
-                name="zipCode"
-                value={formData.zipCode}
-                onChange={handleChange}
+                name="zonecode"
+                value={formData.zonecode || ''}
                 readOnly
                 placeholder="우편번호"
                 className="w-32 px-4 py-3 rounded-xl border border-neutral-200 bg-neutral-50 focus:outline-none"
@@ -145,8 +169,7 @@ const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => 
             <input
               type="text"
               name="address"
-              value={formData.address}
-              onChange={handleChange}
+              value={formData.address || ''}
               readOnly
               placeholder="기본 주소 (주소 검색 후 자동 입력됩니다)"
               className="w-full px-4 py-3 rounded-xl border border-neutral-200 bg-neutral-50 focus:outline-none"
@@ -154,12 +177,28 @@ const ShippingInfoForm = ({ shippingInfo, onUpdate }: ShippingInfoFormProps) => 
             <input
               type="text"
               name="detailAddress"
-              value={formData.detailAddress}
+              value={formData.detailAddress || ''}
               onChange={handleChange}
               placeholder="상세 주소를 입력해 주세요"
               className="w-full px-4 py-3 rounded-xl border border-neutral-200 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-[border-color,box-shadow]"
             />
           </div>
+
+          {/* 배송지 저장 여부 */}
+          {onSaveAddressChange && (
+            <div className="pt-2 flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="save-address"
+                checked={saveAddress}
+                onChange={(e) => onSaveAddressChange(e.target.checked)}
+                className="w-4 h-4 text-primary-600 rounded border-neutral-300 focus:ring-primary-500"
+              />
+              <label htmlFor="save-address" className="text-sm text-neutral-600 font-medium cursor-pointer">
+                이 배송지를 주소록에 저장
+              </label>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -7,7 +7,6 @@ import { useNavigate, Navigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useOrderStore } from '../stores/useOrderStore';
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left';
-
 import OrderItemList from '../components/features/order/OrderItemList';
 import ShippingInfoForm from '../components/features/order/ShippingInfoForm';
 import OrderSummary from '../components/features/order/OrderSummary';
@@ -16,6 +15,8 @@ import { CouponSelector } from '../components/features/order/CouponSelector';
 import { calculateCouponDiscount, type UserCoupon } from '../components/features/order/couponUtils';
 import { useToast } from '../components/common/Toast';
 import type { AxiosError } from 'axios';
+import { AddressSelectionModal } from '../components/features/address/AddressSelectionModal';
+import { addressService } from '../services/addressService';
 
 const OrderPage = () => {
   const navigate = useNavigate();
@@ -37,25 +38,49 @@ const OrderPage = () => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [selectedCoupon, setSelectedCoupon] = useState<UserCoupon | null>(null);
+  const [isAddressModalOpen, setIsAddressModalOpen] = useState(false);
+  const [saveAddress, setSaveAddress] = useState(false);
 
   useEffect(() => {
     setCouponUuid(null);
     setCouponDiscountAmount(0);
   }, [setCouponUuid, setCouponDiscountAmount]);
 
-  // 로그인 유저 배송지 초기값 바인딩
+  // 로그인 유저 기본 배송지 또는 정보 바인딩
   useEffect(() => {
     if (user && !shippingInfo) {
-      setShippingInfo({
-        id: '-1',
-        name: '기본 배송지',
-        isDefault: true,
-        recipient: user.nickname || '',
-        phone: '', // 임시 빈값
-        zipCode: '',
-        address: '',
-        detailAddress: ''
-      });
+      const fetchDefaultAddress = async () => {
+        try {
+          const defaultAddr = await addressService.getDefaultAddress();
+          if (defaultAddr) {
+            setShippingInfo(defaultAddr);
+          } else {
+            setShippingInfo({
+              id: 0,
+              name: '기본 배송지',
+              isDefault: true,
+              recipient: user.nickname || '',
+              phone: '',
+              zonecode: '',
+              address: '',
+              detailAddress: ''
+            });
+          }
+        } catch (error) {
+          // 기본 배송지가 없는 경우 사용자 정보로 초기화
+          setShippingInfo({
+            id: 0,
+            name: '기본 배송지',
+            isDefault: true,
+            recipient: user.nickname || '',
+            phone: '',
+            zonecode: '',
+            address: '',
+            detailAddress: ''
+          });
+        }
+      };
+      fetchDefaultAddress();
     }
   }, [user, shippingInfo, setShippingInfo]);
 
@@ -82,11 +107,11 @@ const OrderPage = () => {
   const couponDiscount = calculateCouponDiscount(selectedCoupon, totalProductPrice);
   const finalPriceWithCoupon = finalPrice;
   
-  // 배송지 유효성 검사 (MVP: 직접 입력 시 필수 필드 체크)
+  // 배송지 유효성 검사
   const isFormValid = !!(
     shippingInfo?.recipient &&
     shippingInfo?.phone &&
-    shippingInfo?.zipCode &&
+    shippingInfo?.zonecode &&
     shippingInfo?.address &&
     shippingInfo?.detailAddress
   );
@@ -97,7 +122,23 @@ const OrderPage = () => {
     setIsLoading(true);
     
     try {
-      // 실데이터 연동: 백엔드 주문 생성 API 호출
+      // 주소록 저장 옵션이 체크된 경우 주소록에 추가 (ID가 0이거나 없을 때만 신규 저장)
+      if (saveAddress && (!shippingInfo.id || shippingInfo.id === 0)) {
+        try {
+          await addressService.addAddress({
+            name: shippingInfo.name || '최근 사용 배송지',
+            recipient: shippingInfo.recipient,
+            phone: shippingInfo.phone,
+            address: shippingInfo.address,
+            detailAddress: shippingInfo.detailAddress,
+            zonecode: shippingInfo.zonecode
+          });
+        } catch (error) {
+          console.warn('Address saving failed, but proceeding with order:', error);
+        }
+      }
+
+      // 백엔드 주문 생성 API 호출
       const orderRequest = {
         address: `${shippingInfo.address} ${shippingInfo.detailAddress}`,
         recipient: shippingInfo.recipient,
@@ -115,10 +156,9 @@ const OrderPage = () => {
       const response = await orderService.createOrder(orderRequest);
       
       setOrderUuid(response.orderUuid);
-      setOrderResponseItems(response.items); // 주문 응답의 items 저장 (결제 요청에 사용)
+      setOrderResponseItems(response.items); 
       setCouponUuid(selectedCoupon?.uuid || null);
       
-      // 토스 결제 위젯 페이지로 이동
       navigate('/checkout');
     } catch (error: unknown) {
       console.error('Order creation failed:', error);
@@ -148,10 +188,13 @@ const OrderPage = () => {
         <div className="grid grid-cols-1 gap-5 min-[360px]:gap-6 lg:grid-cols-3">
           {/* 왼쪽: 주문 정보 입력 */}
           <div className="lg:col-span-2 space-y-6">
-            {/* 배송지 정보 (직접 입력) */}
+            {/* 배송지 정보 */}
             <ShippingInfoForm 
               shippingInfo={shippingInfo} 
-              onUpdate={setShippingInfo} 
+              onUpdate={setShippingInfo}
+              onSelectAddressbook={() => setIsAddressModalOpen(true)}
+              saveAddress={saveAddress}
+              onSaveAddressChange={setSaveAddress}
             />
 
             {/* 주문 상품 */}
@@ -160,7 +203,7 @@ const OrderPage = () => {
             <CouponSelector
               orderAmount={totalProductPrice}
               selectedCoupon={selectedCoupon}
-              onSelectCoupon={(coupon) => {
+              onSelectCoupon={(coupon: UserCoupon | null) => {
                 setSelectedCoupon(coupon);
                 setCouponUuid(coupon?.uuid ?? null);
                 setCouponDiscountAmount(coupon ? calculateCouponDiscount(coupon, totalProductPrice) : 0);
@@ -191,6 +234,12 @@ const OrderPage = () => {
           </div>
         </div>
       </div>
+
+      <AddressSelectionModal
+        isOpen={isAddressModalOpen}
+        onClose={() => setIsAddressModalOpen(false)}
+        onSelect={setShippingInfo}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 작업 내용\n- 주문서에서 주소 선택 모달 연동\n- 배송지 폼에 주소록 선택 버튼/저장 옵션 추가\n- 기본 배송지 조회와 주문 시 주소 저장 플로우 반영\n- 배송지 유효성 검사 필드 정리(zonecode)\n\n## 관련 이슈\n- Closes #193