### PR TITLE
feat(admin-settlement): 즉시 트리거 수동 실행 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ coverage/
 # package-lock.json
 # yarn.lock
 # pnpm-lock.yaml
+
+# Codex local temp
+.codex-tmp/

--- a/src/components/features/admin/AdminSettlementList.tsx
+++ b/src/components/features/admin/AdminSettlementList.tsx
@@ -8,9 +8,10 @@ import { useToast } from '@/components/common/Toast';
 import { adminService } from '@/services/adminService';
 import type {
   AdminSettlementDetailResponse,
-  AdminSettlementStatus,
   AdminSettlementStatisticsResponse,
+  AdminSettlementStatus,
 } from '@/types/admin';
+import { parseHttpError } from '@/utils/httpError';
 
 const STATUS_LABELS: Record<AdminSettlementStatus, { text: string; color: string }> = {
   CREATED: { text: '생성됨', color: 'bg-neutral-100 text-neutral-700' },
@@ -26,6 +27,8 @@ const parseDate = (value: string) => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+const canTriggerImmediate = (status: AdminSettlementStatus) => status === 'PENDING';
+
 export function AdminSettlementList() {
   const [settlements, setSettlements] = useState<AdminSettlementDetailResponse[]>([]);
   const [statistics, setStatistics] = useState<AdminSettlementStatisticsResponse | null>(null);
@@ -33,6 +36,7 @@ export function AdminSettlementList() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [triggeringSettlementUuid, setTriggeringSettlementUuid] = useState<string | null>(null);
   const { showToast } = useToast();
 
   const loadSettlements = useCallback(async () => {
@@ -87,8 +91,43 @@ export function AdminSettlementList() {
     return parsed.toLocaleDateString('ko-KR');
   };
 
+  const handleImmediateTrigger = async (settlement: AdminSettlementDetailResponse) => {
+    if (!canTriggerImmediate(settlement.status)) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `정산 건을 즉시 처리하시겠습니까?\n정산 UUID: ${settlement.settlementUuid}`,
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setTriggeringSettlementUuid(settlement.settlementUuid);
+    try {
+      await adminService.runAdminSettlementImmediate(settlement.settlementUuid);
+      showToast('즉시 정산 트리거를 요청했습니다. 배치 로그에서 진행 상태를 확인하세요.', 'success');
+      await loadSettlements();
+    } catch (error) {
+      showToast(parseHttpError(error, '정산 즉시 트리거 요청에 실패했어요.'), 'error');
+    } finally {
+      setTriggeringSettlementUuid(null);
+    }
+  };
+
   return (
     <div className="space-y-4">
+      <div className="flex items-start gap-3 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="text-sm text-blue-800">
+          <p className="font-medium mb-1">정산 자동 처리 안내</p>
+          <ul className="list-disc list-inside space-y-1 text-blue-700">
+            <li>구매확정 완료 시 자동으로 정산 대기 목록에 등록됩니다.</li>
+            <li>매일 자정(00:00 KST) 일괄 지급 처리됩니다.</li>
+            <li>관리자 테스트 목적의 즉시 트리거는 PENDING 건에서만 가능합니다.</li>
+          </ul>
+        </div>
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="bg-white p-4 rounded-lg border border-neutral-200">
           <p className="text-sm text-neutral-500">정산 대기/예정</p>
@@ -141,7 +180,7 @@ export function AdminSettlementList() {
           </div>
         ) : filteredSettlements.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[980px]">
+            <table className="w-full min-w-[1150px]">
               <thead className="bg-neutral-50 border-b border-neutral-200">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">상태</th>
@@ -150,6 +189,7 @@ export function AdminSettlementList() {
                   <th className="px-4 py-3 text-right text-sm font-medium text-neutral-700">정산금액</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">생성일</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-neutral-700">처리일</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-neutral-700">즉시트리거</th>
                   <th className="px-4 py-3 text-right text-sm font-medium text-neutral-700">상세</th>
                 </tr>
               </thead>
@@ -175,6 +215,26 @@ export function AdminSettlementList() {
                           ? formatDate(settlement.completedAt)
                           : `${formatDateOnly(settlement.settlementReservationDate)} 예정`}
                       </td>
+                      <td className="px-4 py-3 text-center">
+                        {canTriggerImmediate(settlement.status) ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            isLoading={triggeringSettlementUuid === settlement.settlementUuid}
+                            disabled={
+                              triggeringSettlementUuid !== null &&
+                              triggeringSettlementUuid !== settlement.settlementUuid
+                            }
+                            onClick={() => {
+                              void handleImmediateTrigger(settlement);
+                            }}
+                          >
+                            즉시 실행
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-neutral-400">-</span>
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-right">
                         <button
                           type="button"
@@ -194,8 +254,12 @@ export function AdminSettlementList() {
                     </tr>
                     {expandedId === settlement.settlementUuid && (
                       <tr id={`admin-settlement-detail-${settlement.settlementUuid}`} className="bg-neutral-50">
-                        <td colSpan={7} className="px-4 py-4">
-                          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                        <td colSpan={8} className="px-4 py-4">
+                          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                            <div>
+                              <p className="text-xs text-neutral-500">정산 UUID</p>
+                              <p className="text-sm font-medium">{settlement.settlementUuid}</p>
+                            </div>
                             <div>
                               <p className="text-xs text-neutral-500">주문번호</p>
                               <p className="text-sm font-medium">{settlement.orderUuid}</p>

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -70,6 +70,30 @@ const requestSettlementApi = async <T>(path: string, params?: object): Promise<T
   throw lastError ?? new Error('정산 API 호출에 실패했어요.');
 };
 
+const requestSettlementMutation = async (path: string): Promise<void> => {
+  let lastError: unknown;
+
+  for (const [index, base] of settlementBaseCandidates.entries()) {
+    try {
+      await api.post(`${base}${path}`);
+      return;
+    } catch (error) {
+      lastError = error;
+
+      const isLastCandidate = index === settlementBaseCandidates.length - 1;
+      if (!axios.isAxiosError(error)) {
+        throw error;
+      }
+
+      if (isLastCandidate || error.response?.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError ?? new Error('정산 API 호출에 실패했어요.');
+};
+
 const getSellerProfiles = async (productUuids: string[]) => {
   const uniqueProductUuids = Array.from(new Set(productUuids));
   const profileMap = new Map<string, UserAdminProfileResponse>();
@@ -142,6 +166,10 @@ export const adminService = {
     params: AdminSettlementStatisticsParams = {},
   ): Promise<AdminSettlementStatisticsResponse> => {
     return requestSettlementApi<AdminSettlementStatisticsResponse>('/statistics', params);
+  },
+
+  runAdminSettlementImmediate: async (settlementUuid: string): Promise<void> => {
+    await requestSettlementMutation(`/${settlementUuid}/batch/immediate`);
   },
 
   getAdminUsers: async (params: AdminUserSearchParams = {}): Promise<AdminUserPageResponse> => {


### PR DESCRIPTION
## 변경 내용
- 관리자 정산 목록에서 PENDING 상태 정산 건에 즉시 실행 버튼을 추가했습니다.
- 즉시 실행 클릭 시 단건 즉시 트리거 API를 호출하고, 성공/실패 토스트 및 로딩 상태를 반영합니다.
- 즉시 실행 성공 시 정산 목록/통계를 재조회해 최신 상태를 반영합니다.
- settlement mutation API 호출에도 BASE/LEGACY fallback 경로를 동일하게 적용했습니다.
- Codex 임시 산출물 디렉터리(.codex-tmp/)를 .gitignore에 추가했습니다.

## 검증
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 정산 즉시 실행 기능 추가 - PENDING 상태의 정산에 대해 "즉시 실행" 버튼으로 즉시 처리 가능
  * 정산 상세 정보에 정산 UUID 표시 추가

* **개선 사항**
  * 즉시 실행 중 로딩 상태 및 오류 처리 개선

* **기타**
  * 저장소 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->